### PR TITLE
Make callback URL optional in DB

### DIFF
--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -139,7 +139,7 @@ CREATE TABLE dcsa_ebl_v1_0.shipping_instruction (
 	number_of_originals integer NULL,
 	freight_payable_at uuid NOT NULL,
 	is_electronic boolean NULL,
-	display_charges boolean NOT NULL,
+	is_charges_displayed boolean NOT NULL,
 	callback_url text NULL
 );
 

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -139,6 +139,7 @@ CREATE TABLE dcsa_ebl_v1_0.shipping_instruction (
 	number_of_originals integer NULL,
 	freight_payable_at uuid NOT NULL,
 	is_electronic boolean NULL,
+	display_charges boolean NOT NULL,
 	callback_url text NULL
 );
 

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -139,7 +139,7 @@ CREATE TABLE dcsa_ebl_v1_0.shipping_instruction (
 	number_of_originals integer NULL,
 	freight_payable_at uuid NOT NULL,
 	is_electronic boolean NULL,
-	callback_url text NOT NULL
+	callback_url text NULL
 );
 
 DROP TABLE IF EXISTS dcsa_ebl_v1_0.ebl_endorsement_chain CASCADE;


### PR DESCRIPTION
This will enable us to remove it from EBL and the API validator first
before removing it in the DB.  This in turn breaks the circular
dependency between the projects while doing so.

Signed-off-by: Niels Thykier <nt@asseco.dk>