### PR TITLE
Remove tabs from test data

### DIFF
--- a/datamodel/testdata.d/07_test_data_ebl.sql
+++ b/datamodel/testdata.d/07_test_data_ebl.sql
@@ -52,16 +52,16 @@ INSERT INTO dcsa_im_v3_0.location (
 );
 
 INSERT INTO dcsa_im_v3_0.booking (
-	carrier_booking_reference,
-	service_type_at_origin,
-	service_type_at_destination,
-	shipment_term_at_origin,
-	shipment_term_at_destination,
-	booking_datetime,
-	service_contract,
-	commodity_type,
-	cargo_gross_weight,
-	cargo_gross_weight_unit
+    carrier_booking_reference,
+    service_type_at_origin,
+    service_type_at_destination,
+    shipment_term_at_origin,
+    shipment_term_at_destination,
+    booking_datetime,
+    service_contract,
+    commodity_type,
+    cargo_gross_weight,
+    cargo_gross_weight_unit
 ) VALUES (
     'BR1239719871',
     'CY',
@@ -163,39 +163,39 @@ INSERT INTO dcsa_im_v3_0.voyage (
 
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
-	transport_call_sequence_number,
-	facility_code,
-	facility_type_code,
-	other_facility,
-	location_id
+    transport_call_sequence_number,
+    facility_code,
+    facility_type_code,
+    other_facility,
+    location_id
 ) VALUES (
     uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa'),
     1,
     null,
     'POTE',
-	null,
-	uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa')
+    null,
+    uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d879d'),
     uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d879e'),
     uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d879f'),
     uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa')
@@ -203,31 +203,31 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
-	transport_call_sequence_number,
-	facility_code,
-	facility_type_code,
-	other_facility,
-	location_id
+    transport_call_sequence_number,
+    facility_code,
+    facility_type_code,
+    other_facility,
+    location_id
 ) VALUES (
     uuid('770b7624-403d-11eb-b44b-d3f4ad185386'),
     1,
     null,
     'COFS',
-	'test',
-	uuid('770b7624-403d-11eb-b44b-d3f4ad185386')
+    'test',
+    uuid('770b7624-403d-11eb-b44b-d3f4ad185386')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8790'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185386')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8791'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185386')
@@ -235,31 +235,31 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
-	transport_call_sequence_number,
-	facility_code,
-	facility_type_code,
-	other_facility,
-	location_id
+    transport_call_sequence_number,
+    facility_code,
+    facility_type_code,
+    other_facility,
+    location_id
 ) VALUES (
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387'),
     1,
     null,
     'COFS',
-	'test',
-	uuid('770b7624-403d-11eb-b44b-d3f4ad185387')
+    'test',
+    uuid('770b7624-403d-11eb-b44b-d3f4ad185387')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8792'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8793'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387')
@@ -267,44 +267,44 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
-	transport_call_sequence_number,
-	facility_code,
-	facility_type_code,
-	other_facility,
-	location_id
+    transport_call_sequence_number,
+    facility_code,
+    facility_type_code,
+    other_facility,
+    location_id
 ) VALUES (
     uuid('770b7624-403d-11eb-b44b-d3f4ad185388'),
     1,
     null,
     'INTE',
-	'test 123',
-	uuid('770b7624-403d-11eb-b44b-d3f4ad185388')
+    'test 123',
+    uuid('770b7624-403d-11eb-b44b-d3f4ad185388')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8794'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185388')
 );
 
 INSERT INTO dcsa_im_v3_0.transport_call_voyage (
-	voyage_id,
-	transport_call_id
+    voyage_id,
+    transport_call_id
 ) VALUES (
     uuid('84bfcf2e-403b-11eb-bc4a-1fc4aa7d8795'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185388')
 );
 
 INSERT INTO dcsa_im_v3_0.vessel (
-	vessel_imo_number,
-	vessel_name,
-	vessel_flag,
-	vessel_call_sign_number,
-	vessel_operator_carrier_id
+    vessel_imo_number,
+    vessel_name,
+    vessel_flag,
+    vessel_call_sign_number,
+    vessel_operator_carrier_id
 ) VALUES (
-	'1801323',
+    '1801323',
     'Emma Maersk',
     'DK',
     null,
@@ -313,48 +313,48 @@ INSERT INTO dcsa_im_v3_0.vessel (
 
 INSERT INTO dcsa_im_v3_0.transport (
     id,
-	transport_reference,
-	transport_name,
-	mode_of_transport,
-	load_transport_call_id,
-	discharge_transport_call_id,
-	vessel
+    transport_reference,
+    transport_name,
+    mode_of_transport,
+    load_transport_call_id,
+    discharge_transport_call_id,
+    vessel
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e1f'),
     'transport reference',
     'Transport name',
     '1',
-	uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa'),
-	uuid('770b7624-403d-11eb-b44b-d3f4ad185386'),
-	'1801323'
+    uuid('286c605e-4043-11eb-9c0b-7b4196cf71fa'),
+    uuid('770b7624-403d-11eb-b44b-d3f4ad185386'),
+    '1801323'
 );
 
 INSERT INTO dcsa_im_v3_0.transport (
     id,
-	transport_reference,
-	transport_name,
-	mode_of_transport,
-	load_transport_call_id,
-	discharge_transport_call_id,
-	vessel
+    transport_reference,
+    transport_name,
+    mode_of_transport,
+    load_transport_call_id,
+    discharge_transport_call_id,
+    vessel
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e2f'),
     'transport reference xx',
     'Transport name xx',
     '2',
-	uuid('770b7624-403d-11eb-b44b-d3f4ad185386'),
+    uuid('770b7624-403d-11eb-b44b-d3f4ad185386'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387'),
-	null
+    null
 );
 
 INSERT INTO dcsa_im_v3_0.transport (
     id,
-	transport_reference,
-	transport_name,
-	mode_of_transport,
-	load_transport_call_id,
-	discharge_transport_call_id,
-	vessel
+    transport_reference,
+    transport_name,
+    mode_of_transport,
+    load_transport_call_id,
+    discharge_transport_call_id,
+    vessel
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e3f'),
     'transport reference yy',
@@ -362,15 +362,15 @@ INSERT INTO dcsa_im_v3_0.transport (
     '2',
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387'),
     uuid('770b7624-403d-11eb-b44b-d3f4ad185388'),
-	null
+    null
 );
 
 INSERT INTO dcsa_im_v3_0.shipment_transport (
-	shipment_id,
-	transport_id,
-	sequence_number,
-	commercial_voyage_id,
-	is_under_shippers_responsibility
+    shipment_id,
+    transport_id,
+    sequence_number,
+    commercial_voyage_id,
+    is_under_shippers_responsibility
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e0f'),
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e1f'),
@@ -380,11 +380,11 @@ INSERT INTO dcsa_im_v3_0.shipment_transport (
 );
 
 INSERT INTO dcsa_im_v3_0.shipment_transport (
-	shipment_id,
-	transport_id,
-	sequence_number,
-	commercial_voyage_id,
-	is_under_shippers_responsibility
+    shipment_id,
+    transport_id,
+    sequence_number,
+    commercial_voyage_id,
+    is_under_shippers_responsibility
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e0f'),
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e2f'),
@@ -394,11 +394,11 @@ INSERT INTO dcsa_im_v3_0.shipment_transport (
 );
 
 INSERT INTO dcsa_im_v3_0.shipment_transport (
-	shipment_id,
-	transport_id,
-	sequence_number,
-	commercial_voyage_id,
-	is_under_shippers_responsibility
+    shipment_id,
+    transport_id,
+    sequence_number,
+    commercial_voyage_id,
+    is_under_shippers_responsibility
 ) VALUES (
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e0f'),
     uuid('561a5606-402e-11eb-b19a-0f3aa4962e3f'),

--- a/datamodel/testdata.d/07_test_data_tnt.sql
+++ b/datamodel/testdata.d/07_test_data_tnt.sql
@@ -4,16 +4,16 @@
 BEGIN;
 
 INSERT INTO dcsa_im_v3_0.booking (
-	carrier_booking_reference,
-	service_type_at_origin,
-	service_type_at_destination,
-	shipment_term_at_origin,
-	shipment_term_at_destination,
-	booking_datetime,
-	service_contract,
-	commodity_type,
-	cargo_gross_weight,
-	cargo_gross_weight_unit
+    carrier_booking_reference,
+    service_type_at_origin,
+    service_type_at_destination,
+    shipment_term_at_origin,
+    shipment_term_at_destination,
+    booking_datetime,
+    service_contract,
+    commodity_type,
+    cargo_gross_weight,
+    cargo_gross_weight_unit
 ) VALUES (
     'BR1239719971',
     'CY',
@@ -29,16 +29,16 @@ INSERT INTO dcsa_im_v3_0.booking (
 
 
 INSERT INTO dcsa_im_v3_0.booking (
-	carrier_booking_reference,
-	service_type_at_origin,
-	service_type_at_destination,
-	shipment_term_at_origin,
-	shipment_term_at_destination,
-	booking_datetime,
-	service_contract,
-	commodity_type,
-	cargo_gross_weight,
-	cargo_gross_weight_unit
+    carrier_booking_reference,
+    service_type_at_origin,
+    service_type_at_destination,
+    shipment_term_at_origin,
+    shipment_term_at_destination,
+    booking_datetime,
+    service_contract,
+    commodity_type,
+    cargo_gross_weight,
+    cargo_gross_weight_unit
 ) VALUES (
     'BR1239719872',
     'CY',


### PR DESCRIPTION
It makes it harder to copy-paste the data into an interactive psql
session as psql interprets the tab as a "tab-completion" request,
which can alter the query (causing it to use non-exisiting field
names).

Signed-off-by: Niels Thykier <nt@asseco.dk>