### PR TITLE
Update 03_dcsa_im_v3_0.sql

### DIFF
--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -459,8 +459,7 @@ CREATE TABLE dcsa_im_v3_0.facility (
     un_location_code varchar(5) NULL,
     latitude varchar(10) NULL,
     longitude varchar(11) NULL,
-    address varchar(250) NULL,
-    facility_type_code varchar(4) NULL
+    address varchar(250) NULL
 );
 
 DROP TABLE IF EXISTS dcsa_im_v3_0.facility_type CASCADE;


### PR DESCRIPTION
Facility Type codes should be stored in the transport call.  The Facility Entity should not be dependant upon a type, as many facilities offer various services in the same location, this would lead to duplication of facilities where coding is needed.  In the transport call where it meet the means of transport it would make sense.