### PR TITLE
Refer to facility by id rather than code.

### DIFF
--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -70,8 +70,9 @@ DROP TABLE IF EXISTS dcsa_im_v3_0.facility CASCADE;
 CREATE TABLE dcsa_im_v3_0.facility (
     id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
     facility_name varchar(100) NULL,
-    facility_bic_code varchar(11) NULL, -- prefixed with UN Locode
-    facility_smdg_code varchar(4) NULL, -- without UN Locode
+    un_location_code varchar(7) NULL, -- The UN Locode prefixing the BIC / SMDG code
+    facility_bic_code varchar(4) NULL, -- suffix uniquely identifying the facility when prefixed with the UN Locode
+    facility_smdg_code varchar(3) NULL, -- suffix uniquely identifying the facility when prefixed with the UN Locode
     location varchar(100) REFERENCES dcsa_im_v3_0.location (id)
 );
 

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -68,10 +68,10 @@ CREATE TABLE dcsa_im_v3_0.facility_type (
 
 DROP TABLE IF EXISTS dcsa_im_v3_0.facility CASCADE;
 CREATE TABLE dcsa_im_v3_0.facility (
-    facility_code varchar(11) PRIMARY KEY,
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
     facility_name varchar(100) NULL,
-    code_list_provider_code varchar(6) NULL,
-    code_list_provider varchar(8) NULL,
+    facility_bic_code varchar(11) NULL, -- prefixed with UN Locode
+    facility_smdg_code varchar(4) NULL, -- without UN Locode
     location varchar(100) REFERENCES dcsa_im_v3_0.location (id)
 );
 
@@ -90,9 +90,9 @@ DROP TABLE IF EXISTS dcsa_im_v3_0.transport_call CASCADE;
 CREATE TABLE dcsa_im_v3_0.transport_call (
     id varchar(100) PRIMARY KEY,
     transport_call_sequence_number integer,
-    facility_code varchar(11) NULL REFERENCES dcsa_im_v3_0.facility (facility_code),
+    facility uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
     facility_type_code char(4) NULL REFERENCES dcsa_im_v3_0.facility_type (facility_type_code),
-    other_facility varchar(50) NULL,
+    other_facility uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
     location_id varchar(100) NULL REFERENCES dcsa_im_v3_0.location (id)
 );
 

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -101,7 +101,7 @@ CREATE TABLE dcsa_im_v3_0.transport_call (
     transport_call_sequence_number integer,
     facility uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
     facility_type_code char(4) NULL REFERENCES dcsa_im_v3_0.facility_type (facility_type_code),
-    other_facility uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
+    other_facility varchar(50) NULL, -- Free text field used if the facility cannot be identified
     location_id varchar(100) NULL REFERENCES dcsa_im_v3_0.location (id)
 );
 

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -76,6 +76,14 @@ CREATE TABLE dcsa_im_v3_0.facility (
     location varchar(100) REFERENCES dcsa_im_v3_0.location (id)
 );
 
+DROP TABLE IF EXISTS dcsa_im_v3_0.carrier CASCADE;
+CREATE TABLE dcsa_im_v3_0.carrier (
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    carrier_name varchar(100),
+    smdg_code varchar(3) NULL,
+    nmfta_code varchar(4) NULL
+);
+
 DROP TABLE IF EXISTS dcsa_im_v3_0.party CASCADE;
 CREATE TABLE dcsa_im_v3_0.party (
     id varchar(100) DEFAULT uuid_generate_v4()::text PRIMARY KEY,
@@ -198,7 +206,7 @@ CREATE TABLE dcsa_im_v3_0.transport_document (
     received_for_shipment_date date NULL,
     terms_and_conditions text NULL,
     number_of_originals integer NULL, --number of originals if different from number requeste by shipper (on SI)
-    issuer varchar(4) NULL,
+    issuer uuid NULL REFERENCES dcsa_im_v3_0.carrier(id),
     shipping_instruction_id varchar(100) NOT NULL REFERENCES dcsa_im_v3_0.shipping_instruction (id),
     declared_value_currency varchar(3) NULL,
     declared_value real NULL,
@@ -271,14 +279,6 @@ CREATE TABLE dcsa_im_v3_0.displayed_address (
 CREATE INDEX ON dcsa_im_v3_0.displayed_address (party_id, party_function);
 CREATE INDEX ON dcsa_im_v3_0.displayed_address (shipment_id);
 CREATE INDEX ON dcsa_im_v3_0.displayed_address (shipping_instruction_id);
-
-DROP TABLE IF EXISTS dcsa_im_v3_0.carrier CASCADE;
-CREATE TABLE dcsa_im_v3_0.carrier (
-    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
-    carrier_name varchar(100),
-    smdg_code varchar(3) NULL,
-    nmfta_code varchar(4) NULL
-);
 
 DROP TABLE IF EXISTS dcsa_im_v3_0.charges CASCADE;
 CREATE TABLE dcsa_im_v3_0.charges (

--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -461,7 +461,7 @@ CREATE TABLE dcsa_im_v3_0.vessel (
     vessel_name varchar(35) NULL,
     vessel_flag char(2) NULL,
     vessel_call_sign_number varchar(10) NULL,
-    vessel_operator_carrier_id uuid NULL
+    vessel_operator_carrier_id uuid REFERENCES dcsa_im_v3_0.carrier (id)
 );
 
 DROP TABLE IF EXISTS dcsa_im_v3_0.transport CASCADE;

--- a/datamodel/testdata.d/07_test_data_ebl.sql
+++ b/datamodel/testdata.d/07_test_data_ebl.sql
@@ -164,7 +164,7 @@ INSERT INTO dcsa_im_v3_0.voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility_code,
+    facility,
     facility_type_code,
     other_facility,
     location_id
@@ -204,7 +204,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility_code,
+    facility,
     facility_type_code,
     other_facility,
     location_id
@@ -213,7 +213,7 @@ INSERT INTO dcsa_im_v3_0.transport_call (
     1,
     null,
     'COFS',
-    'test',
+    null,
     uuid('770b7624-403d-11eb-b44b-d3f4ad185386')
 );
 
@@ -236,7 +236,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility_code,
+    facility,
     facility_type_code,
     other_facility,
     location_id
@@ -245,7 +245,7 @@ INSERT INTO dcsa_im_v3_0.transport_call (
     1,
     null,
     'COFS',
-    'test',
+    null,
     uuid('770b7624-403d-11eb-b44b-d3f4ad185387')
 );
 
@@ -268,7 +268,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility_code,
+    facility,
     facility_type_code,
     other_facility,
     location_id
@@ -277,7 +277,7 @@ INSERT INTO dcsa_im_v3_0.transport_call (
     1,
     null,
     'INTE',
-    'test 123',
+    null,
     uuid('770b7624-403d-11eb-b44b-d3f4ad185388')
 );
 


### PR DESCRIPTION
This is a better fit with the ER approach used in the IM.
Also explicitly include BIC/SMDG/NMFTA codes allowing for two codes
to be stored per carrier and facility.