### PR TITLE
Update referencetypes.csv

### DIFF
--- a/datamodel/referencedata.d/referencetypes.csv
+++ b/datamodel/referencedata.d/referencetypes.csv
@@ -4,4 +4,3 @@ SI,Shipper’s Reference,Reference assigned to the shipment by the shipper.
 PO,Purchase Order Reference,The PO reference that the shipper or freight forwarder received from the consignee and then shared with the carrier.
 CR,Customer’s Reference,Reference assigned to the shipment by the customer.
 AAO,Consignee’s Reference,Reference assigned to the shipment by the consignee.
-EQ,Equipment Number,Number assigned by the manufacturer to specific equipment.


### PR DESCRIPTION
It is agreed that VGM is removed from ShipmentEvents - EQ was the only reason from keeping this enum value