### PR TITLE
Correct name of facility_id in transport_call

### DIFF
--- a/datamodel/initdb.d/03_dcsa_im_v3_0.sql
+++ b/datamodel/initdb.d/03_dcsa_im_v3_0.sql
@@ -99,7 +99,7 @@ DROP TABLE IF EXISTS dcsa_im_v3_0.transport_call CASCADE;
 CREATE TABLE dcsa_im_v3_0.transport_call (
     id varchar(100) PRIMARY KEY,
     transport_call_sequence_number integer,
-    facility uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
+    facility_id uuid NULL REFERENCES dcsa_im_v3_0.facility (id),
     facility_type_code char(4) NULL REFERENCES dcsa_im_v3_0.facility_type (facility_type_code),
     other_facility varchar(50) NULL, -- Free text field used if the facility cannot be identified
     location_id varchar(100) NULL REFERENCES dcsa_im_v3_0.location (id)

--- a/datamodel/testdata.d/07_test_data_ebl.sql
+++ b/datamodel/testdata.d/07_test_data_ebl.sql
@@ -164,7 +164,7 @@ INSERT INTO dcsa_im_v3_0.voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility,
+    facility_id,
     facility_type_code,
     other_facility,
     location_id
@@ -204,7 +204,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility,
+    facility_id,
     facility_type_code,
     other_facility,
     location_id
@@ -236,7 +236,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility,
+    facility_id,
     facility_type_code,
     other_facility,
     location_id
@@ -268,7 +268,7 @@ INSERT INTO dcsa_im_v3_0.transport_call_voyage (
 INSERT INTO dcsa_im_v3_0.transport_call (
     id,
     transport_call_sequence_number,
-    facility,
+    facility_id,
     facility_type_code,
     other_facility,
     location_id


### PR DESCRIPTION
I assume the omission of `_id` was a mistake.