### PR TITLE
Fix SMDG Liner Code broken link in the README file

### DIFF
--- a/datamodel/samples.d/README.md
+++ b/datamodel/samples.d/README.md
@@ -17,7 +17,7 @@ Data sources
 Below is a list of the data sources for each the files maintained on a
 best-effort basis.  Corrections are welcome (via PR).
 
- * carriers.csv: Subset of https://smdg.org/documents/smdg-code-lists/smdg-liner-codes/
+ * carriers.csv: Subset of https://smdg.org/documents/smdg-code-lists/smdg-liner-code-list/
 
  * countrycodes.csv: Subset of https://unece.org/trade/cefact/unlocode-code-list-country-and-territory
 


### PR DESCRIPTION
SMDG website has changed the link of Liner Code List. The link in the README file was broken.