### PR TITLE
Simplify our timestamp definitions

### DIFF
--- a/datamodel/initdb.d/05_reference_implementation_support.sql
+++ b/datamodel/initdb.d/05_reference_implementation_support.sql
@@ -579,8 +579,7 @@ CREATE TABLE dcsa_im_v3_0.timestamp_definition (
     negotiation_cycle text NOT NULL REFERENCES dcsa_im_v3_0.negotiation_cycle(cycle_key),
     provided_in_standard text NOT NULL,
     accept_timestamp_definition text NULL REFERENCES dcsa_im_v3_0.timestamp_definition(id) INITIALLY DEFERRED,
-    reject_timestamp_definition text NULL REFERENCES dcsa_im_v3_0.timestamp_definition(id) INITIALLY DEFERRED,
-    canonical_timestamp_definition text NULL REFERENCES dcsa_im_v3_0.timestamp_definition(id) INITIALLY DEFERRED
+    reject_timestamp_definition text NULL REFERENCES dcsa_im_v3_0.timestamp_definition(id) INITIALLY DEFERRED
 );
 
 

--- a/datamodel/samples.d/timestampdefinitions.csv
+++ b/datamodel/samples.d/timestampdefinitions.csv
@@ -1,78 +1,58 @@
-id,timestampTypeName,publisherRole,primaryReceiver,eventClassifierCode,operationsEventTypeCode,portCallPhaseTypeCode,portCallServiceTypeCode,facilityTypeCode,isBerthLocationNeeded,isPBPLocationNeeded,isTerminalNeeded,isVesselPositionNeeded,negotiationCycle,providedInStandard,acceptTimestampDefinition,rejectTimestampDefinition,canonicalTimestampDefinition
-UC1,ETA-Berth,CA,TR,EST,ARRI,INBD,null,BRTH,false,false,true,true,TA-Berth,jit1_0,UC2,UC2,null
-UC2,RTA-Berth,TR,CA,REQ,ARRI,INBD,null,BRTH,true,false,true,false,TA-Berth,jit1_0,UC3,UC1,null
-UC3,PTA-Berth,CA,TR,PLN,ARRI,INBD,null,BRTH,true,false,true,true,TA-Berth,jit1_0,null,null,null
-UC4,ETS-Cargo Ops,TR,CA,EST,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,UC5,UC5,null
-UC5,RTS-Cargo Ops,CA,TR,REQ,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,UC6,UC6,null
-UC6,PTS-Cargo Ops,TR,CA,PLN,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,null,null,null
-UC7,ETA-PBP,CA,ATH,EST,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,UC12,UC12,null
-UC8,RTS-Pilotage (Inbound),ATH,PLT,REQ,STRT,INBD,PILO,null,false,true,true,false,T-Pilotage-Arrival,jit1_1,UC10,null,null
-UC9,RTS-Towage (Inbound),ATH,TWG,REQ,STRT,INBD,TOWG,null,false,true,true,false,T-Towage-Arrival,jit1_1,UC11,null,null
-UC10,PTS-Pilotage (Inbound),PLT,ATH,PLN,STRT,INBD,PILO,null,false,true,true,false,T-Pilotage-Arrival,jit1_1,null,null,null
-UC11,PTS-Towage (Inbound),TWG,ATH,PLN,STRT,INBD,TOWG,null,false,true,true,false,T-Towage-Arrival,jit1_1,null,null,null
-UC12,RTA-PBP,ATH,CA,REQ,ARRI,INBD,null,PBPL,false,true,false,false,TA-PBP,jit1_0,UC13,UC7,null
-UC13,PTA-PBP,CA,ATH,PLN,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,null,null,null
-UC14,ETS-Bunkering,BUK,VSL,EST,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC16,UC16,null
-UC15,ETC-Bunkering,BUK,VSL,EST,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC17,UC17,null
-UC16,RTS-Bunkering,VSL,BUK,REQ,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC18,UC14,null
-UC17,RTC-Bunkering,VSL,BUK,REQ,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC19,UC15,null
-UC18,PTS-Bunkering,BUK,VSL,PLN,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null,null
-UC19,PTC-Bunkering,BUK,VSL,PLN,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null,null
-UC20,EOSP,CA,ATH,ACT,ARRI,INBD,null,null,false,false,false,true,Special,jit1_1,null,null,null
-UC21,ATA-PBP,CA,ATH,ACT,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,null,null,null
-UC22,ATS-Pilotage (Inbound),PLT,ATH,ACT,STRT,INBD,PILO,null,false,false,true,true,T-Pilotage-Arrival,jit1_1,null,null,null
-UC23,ATS-Towage (Inbound),TWG,ATH,ACT,STRT,INBD,TOWG,null,false,false,true,true,T-Towage-Arrival,jit1_1,null,null,null
-UC24,ATC-Towage (Inbound),TWG,ATH,ACT,CMPL,INBD,TOWG,null,false,false,true,true,T-Towage-Arrival,jit1_1,null,null,null
-UC25,ATA-Berth,VSL,ATH,ACT,ARRI,ALGS,null,BRTH,true,false,true,false,TA-Berth,jit1_0,null,null,null
-UC26,AT-All fast,VSL,ATH,ACT,ARRI,ALGS,FAST,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null,null
-UC27,Gangway down and safe,VSL,ATH,ACT,ARRI,ALGS,GWAY,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null,null
-UC28,Vessel Readiness for cargo operations,VSL,TR,ACT,ARRI,ALGS,SAFE,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null,null
-UC29,ATS-Cargo Ops,TR,CA,ACT,STRT,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null,null
-UC30,ETC-Cargo Ops,TR,CA,EST,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,UC31,UC31,null
-UC31,RTC-Cargo Ops,CA,TR,REQ,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,UC32,UC30,null
-UC32,PTC-Cargo Ops,TR,CA,PLN,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null,null
-UC33,ATS-Bunkering,BUK,VSL,ACT,STRT,ALGS,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null,null
-UC34,ETD-Berth,VSL,ATH,EST,DEPA,ALGS,null,BRTH,false,false,true,true,TD-Berth,jit1_0,UC39,UC39,null
-UC35-SHIFT,RTS-Pilotage (Shift),ATH,PLT,REQ,STRT,SHIF,PILO,null,false,true,true,false,T-Pilotage-Shift,jit1_1,UC37-SHIFT,null,null
-UC36-SHIFT,RTS-Towage (Shift),ATH,TWG,REQ,STRT,SHIF,TOWG,null,false,true,true,false,T-Towage-Shift,jit1_1,UC38-SHIFT,null,null
-UC37-SHIFT,PTS-Pilotage (Shift),PLT,ATH,PLN,STRT,SHIF,PILO,null,false,true,true,false,T-Pilotage-Shift,jit1_1,null,null,null
-UC38-SHIFT,PTS-Towage (Shift),TWG,ATH,PLN,STRT,SHIF,TOWG,null,false,true,true,false,T-Towage-Shift,jit1_1,null,null,null
-UC35-OUTB,RTS-Pilotage (Outbound),ATH,PLT,REQ,STRT,OUTB,PILO,null,false,true,true,false,T-Pilotage-Outbound,jit1_1,UC37-SHIFT,null,null
-UC36-OUTB,RTS-Towage (Outbound),ATH,TWG,REQ,STRT,OUTB,TOWG,null,false,true,true,false,T-Towage-Outbound,jit1_1,UC38-SHIFT,null,null
-UC37-OUTB,PTS-Pilotage (Outbound),PLT,ATH,PLN,STRT,OUTB,PILO,null,false,true,true,false,T-Pilotage-Outbound,jit1_1,null,null,null
-UC38-OUTB,PTS-Towage (Outbound),TWG,ATH,PLN,STRT,OUTB,TOWG,null,false,true,true,false,T-Towage-Outbound,jit1_1,null,null,null
-UC39,RTD-Berth,ATH,VSL,REQ,DEPA,ALGS,null,BRTH,true,false,true,false,TD-Berth,jit1_0,UC40,UC34,null
-UC40,PTD-Berth,VSL,ATH,PLN,DEPA,ALGS,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,null
-UC41,ATC-Bunkering,BUK,VSL,ACT,CMPL,ALGS,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null,null
-UC42,ATC-Cargo Ops,TR,CA,ACT,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null,null
-UC43,ATC-Lashing,LSH,CA,ACT,CMPL,ALGS,LASH,BRTH,true,false,true,false,Special,jit1_1,null,null,null
-UC44,Terminal ready for vessel departure,TR,VSL,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,null
-UC45,Vessel ready to sail,VSL,TR,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,null
-UC46,ATD-Berth,VSL,ATH,ACT,DEPA,OUTB,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,null
-UC47-SHIF,ATS-Pilotage (Shift),PLT,ATH,ACT,STRT,SHIF,PILO,null,false,false,true,true,T-Pilotage-Shift,jit1_1,null,null,null
-UC48-SHIF,ATS-Towage (Shift),TWG,ATH,ACT,STRT,SHIF,TOWG,null,false,false,true,true,T-Towage-Shift,jit1_1,null,null,null
-UC49-SHIF,ATC-Towage (Shift),TWG,ATH,ACT,CMPL,SHIF,TOWG,null,false,false,true,true,T-Towage-Shift,jit1_1,null,null,null
-UC47-OUTB,ATS-Pilotage (Outbound),PLT,ATH,ACT,STRT,OUTB,PILO,null,false,false,true,true,T-Pilotage-Outbound,jit1_1,null,null,null
-UC48-OUTB,ATS-Towage (Outbound),TWG,ATH,ACT,STRT,OUTB,TOWG,null,false,false,true,true,T-Towage-Outbound,jit1_1,null,null,null
-UC49-OUTB,ATC-Towage (Outbound),TWG,ATH,ACT,CMPL,OUTB,TOWG,null,false,false,true,true,T-Towage-Outbound,jit1_1,null,null,null
-UC50,SOSP,CA,ATH,ACT,DEPA,OUTB,null,null,false,false,false,true,Special,jit1_1,null,null,null
-UC16-ALT-CA,RTS-Bunkering-ALT-CA,CA,BUK,REQ,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC18,UC14,UC16
-UC17-ALT-CA,RTC-Bunkering-ALT-CA,CA,BUK,REQ,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC19,UC15,UC17
-UC25-ALT-CA,ATA-Berth-ALT-CA,CA,ATH,ACT,ARRI,ALGS,null,BRTH,true,false,true,false,TA-Berth,jit1_0,null,null,UC25
-UC26-ALT-CA,AT-All fast-ALT-CA,CA,ATH,ACT,ARRI,ALGS,FAST,BRTH,true,false,true,false,Special,jit1_1,null,null,UC26
-UC27-ALT-CA,Gangway down and safe-ALT-CA,CA,ATH,ACT,ARRI,ALGS,GWAY,BRTH,true,false,true,false,Special,jit1_1,null,null,UC27
-UC28-ALT-CA,Vessel Readiness for cargo operations-ALT-CA,CA,TR,ACT,ARRI,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,UC28
-UC34-ALT-CA,ETD-Berth-ALT-CA,CA,ATH,EST,DEPA,ALGS,null,BRTH,false,false,true,true,TD-Berth,jit1_0,UC39,UC39,UC34
-UC40-ALT-CA,PTD-Berth-ALT-CA,CA,ATH,PLN,DEPA,ALGS,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,UC40
-UC45-ALT-CA,Vessel ready to sail-ALT-CA,CA,TR,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,UC45
-UC46-ALT-CA,ATD-Berth-ALT-CA,CA,ATH,ACT,DEPA,OUTB,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,UC46
-UC16-ALT-AG,RTS-Bunkering-ALT-AG,AG,BUK,REQ,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC18,UC14,UC16
-UC17-ALT-AG,RTC-Bunkering-ALT-AG,AG,BUK,REQ,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC19,UC15,UC17
-UC25-ALT-AG,ATA-Berth-ALT-AG,AG,ATH,ACT,ARRI,ALGS,null,BRTH,true,false,true,false,TA-Berth,jit1_0,null,null,UC25
-UC26-ALT-AG,AT-All fast-ALT-AG,AG,ATH,ACT,ARRI,ALGS,FAST,BRTH,true,false,true,false,Special,jit1_1,null,null,UC26
-UC27-ALT-AG,Gangway down and safe-ALT-AG,AG,ATH,ACT,ARRI,ALGS,GWAY,BRTH,true,false,true,false,Special,jit1_1,null,null,UC27
-UC28-ALT-AG,Vessel Readiness for cargo operations-ALT-AG,AG,TR,ACT,ARRI,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,UC28
-UC34-ALT-AG,ETD-Berth-ALT-AG,AG,ATH,EST,DEPA,ALGS,null,BRTH,false,false,true,true,TD-Berth,jit1_0,UC39,UC39,UC34
-UC40-ALT-AG,PTD-Berth-ALT-AG,AG,ATH,PLN,DEPA,ALGS,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,UC40
-UC45-ALT-AG,Vessel ready to sail-ALT-AG,AG,TR,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null,UC45
-UC46-ALT-AG,ATD-Berth-ALT-AG,AG,ATH,ACT,DEPA,OUTB,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null,UC46
+id,timestampTypeName,publisherRole,primaryReceiver,eventClassifierCode,operationsEventTypeCode,portCallPhaseTypeCode,portCallServiceTypeCode,facilityTypeCode,isBerthLocationNeeded,isPBPLocationNeeded,isTerminalNeeded,isVesselPositionNeeded,negotiationCycle,providedInStandard,acceptTimestampDefinition,rejectTimestampDefinition
+UC1,ETA-Berth,CA,TR,EST,ARRI,INBD,null,BRTH,false,false,true,true,TA-Berth,jit1_0,UC2,UC2
+UC2,RTA-Berth,TR,CA,REQ,ARRI,INBD,null,BRTH,true,false,true,false,TA-Berth,jit1_0,UC3,UC1
+UC3,PTA-Berth,CA,TR,PLN,ARRI,INBD,null,BRTH,true,false,true,true,TA-Berth,jit1_0,null,null
+UC4,ETS-Cargo Ops,TR,CA,EST,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,UC5,UC5
+UC5,RTS-Cargo Ops,CA,TR,REQ,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,UC6,UC6
+UC6,PTS-Cargo Ops,TR,CA,PLN,STRT,INBD,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_1,null,null
+UC7,ETA-PBP,CA,ATH,EST,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,UC12,UC12
+UC8,RTS-Pilotage (Inbound),ATH,PLT,REQ,STRT,INBD,PILO,null,false,true,true,false,T-Pilotage-Arrival,jit1_1,UC10,null
+UC9,RTS-Towage (Inbound),ATH,TWG,REQ,STRT,INBD,TOWG,null,false,true,true,false,T-Towage-Arrival,jit1_1,UC11,null
+UC10,PTS-Pilotage (Inbound),PLT,ATH,PLN,STRT,INBD,PILO,null,false,true,true,false,T-Pilotage-Arrival,jit1_1,null,null
+UC11,PTS-Towage (Inbound),TWG,ATH,PLN,STRT,INBD,TOWG,null,false,true,true,false,T-Towage-Arrival,jit1_1,null,null
+UC12,RTA-PBP,ATH,CA,REQ,ARRI,INBD,null,PBPL,false,true,false,false,TA-PBP,jit1_0,UC13,UC7
+UC13,PTA-PBP,CA,ATH,PLN,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,null,null
+UC14,ETS-Bunkering,BUK,VSL,EST,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC16,UC16
+UC15,ETC-Bunkering,BUK,VSL,EST,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC17,UC17
+UC16,RTS-Bunkering,VSL,BUK,REQ,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC18,UC14
+UC17,RTC-Bunkering,VSL,BUK,REQ,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,UC19,UC15
+UC18,PTS-Bunkering,BUK,VSL,PLN,STRT,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null
+UC19,PTC-Bunkering,BUK,VSL,PLN,CMPL,INBD,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null
+UC20,EOSP,CA,ATH,ACT,ARRI,INBD,null,null,false,false,false,true,Special,jit1_1,null,null
+UC21,ATA-PBP,CA,ATH,ACT,ARRI,INBD,null,PBPL,false,true,false,true,TA-PBP,jit1_0,null,null
+UC22,ATS-Pilotage (Inbound),PLT,ATH,ACT,STRT,INBD,PILO,null,false,false,true,true,T-Pilotage-Arrival,jit1_1,null,null
+UC23,ATS-Towage (Inbound),TWG,ATH,ACT,STRT,INBD,TOWG,null,false,false,true,true,T-Towage-Arrival,jit1_1,null,null
+UC24,ATC-Towage (Inbound),TWG,ATH,ACT,CMPL,INBD,TOWG,null,false,false,true,true,T-Towage-Arrival,jit1_1,null,null
+UC25,ATA-Berth,VSL,ATH,ACT,ARRI,ALGS,null,BRTH,true,false,true,false,TA-Berth,jit1_0,null,null
+UC26,AT-All fast,VSL,ATH,ACT,ARRI,ALGS,FAST,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null
+UC27,Gangway down and safe,VSL,ATH,ACT,ARRI,ALGS,GWAY,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null
+UC28,Vessel Readiness for cargo operations,VSL,TR,ACT,ARRI,ALGS,SAFE,BRTH,true,false,true,false,TA-Berth,jit1_1,null,null
+UC29,ATS-Cargo Ops,TR,CA,ACT,STRT,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null
+UC30,ETC-Cargo Ops,TR,CA,EST,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,UC31,UC31
+UC31,RTC-Cargo Ops,CA,TR,REQ,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,UC32,UC30
+UC32,PTC-Cargo Ops,TR,CA,PLN,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null
+UC33,ATS-Bunkering,BUK,VSL,ACT,STRT,ALGS,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null
+UC34,ETD-Berth,VSL,ATH,EST,DEPA,ALGS,null,BRTH,false,false,true,true,TD-Berth,jit1_0,UC39,UC39
+UC35-SHIFT,RTS-Pilotage (Shift),ATH,PLT,REQ,STRT,SHIF,PILO,null,false,true,true,false,T-Pilotage-Shift,jit1_1,UC37-SHIFT,null
+UC36-SHIFT,RTS-Towage (Shift),ATH,TWG,REQ,STRT,SHIF,TOWG,null,false,true,true,false,T-Towage-Shift,jit1_1,UC38-SHIFT,null
+UC37-SHIFT,PTS-Pilotage (Shift),PLT,ATH,PLN,STRT,SHIF,PILO,null,false,true,true,false,T-Pilotage-Shift,jit1_1,null,null
+UC38-SHIFT,PTS-Towage (Shift),TWG,ATH,PLN,STRT,SHIF,TOWG,null,false,true,true,false,T-Towage-Shift,jit1_1,null,null
+UC35-OUTB,RTS-Pilotage (Outbound),ATH,PLT,REQ,STRT,OUTB,PILO,null,false,true,true,false,T-Pilotage-Outbound,jit1_1,UC37-SHIFT,null
+UC36-OUTB,RTS-Towage (Outbound),ATH,TWG,REQ,STRT,OUTB,TOWG,null,false,true,true,false,T-Towage-Outbound,jit1_1,UC38-SHIFT,null
+UC37-OUTB,PTS-Pilotage (Outbound),PLT,ATH,PLN,STRT,OUTB,PILO,null,false,true,true,false,T-Pilotage-Outbound,jit1_1,null,null
+UC38-OUTB,PTS-Towage (Outbound),TWG,ATH,PLN,STRT,OUTB,TOWG,null,false,true,true,false,T-Towage-Outbound,jit1_1,null,null
+UC39,RTD-Berth,ATH,VSL,REQ,DEPA,ALGS,null,BRTH,true,false,true,false,TD-Berth,jit1_0,UC40,UC34
+UC40,PTD-Berth,VSL,ATH,PLN,DEPA,ALGS,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null
+UC41,ATC-Bunkering,BUK,VSL,ACT,CMPL,ALGS,BUNK,BRTH,true,false,true,false,T-Bunkering,jit1_1,null,null
+UC42,ATC-Cargo Ops,TR,CA,ACT,CMPL,ALGS,CRGO,BRTH,true,false,true,false,T-Cargo-Ops,jit1_0,null,null
+UC43,ATC-Lashing,LSH,CA,ACT,CMPL,ALGS,LASH,BRTH,true,false,true,false,Special,jit1_1,null,null
+UC44,Terminal ready for vessel departure,TR,VSL,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null
+UC45,Vessel ready to sail,VSL,TR,ACT,DEPA,ALGS,SAFE,BRTH,true,false,true,false,Special,jit1_1,null,null
+UC46,ATD-Berth,VSL,ATH,ACT,DEPA,OUTB,null,BRTH,true,false,true,true,TD-Berth,jit1_0,null,null
+UC47-SHIF,ATS-Pilotage (Shift),PLT,ATH,ACT,STRT,SHIF,PILO,null,false,false,true,true,T-Pilotage-Shift,jit1_1,null,null
+UC48-SHIF,ATS-Towage (Shift),TWG,ATH,ACT,STRT,SHIF,TOWG,null,false,false,true,true,T-Towage-Shift,jit1_1,null,null
+UC49-SHIF,ATC-Towage (Shift),TWG,ATH,ACT,CMPL,SHIF,TOWG,null,false,false,true,true,T-Towage-Shift,jit1_1,null,null
+UC47-OUTB,ATS-Pilotage (Outbound),PLT,ATH,ACT,STRT,OUTB,PILO,null,false,false,true,true,T-Pilotage-Outbound,jit1_1,null,null
+UC48-OUTB,ATS-Towage (Outbound),TWG,ATH,ACT,STRT,OUTB,TOWG,null,false,false,true,true,T-Towage-Outbound,jit1_1,null,null
+UC49-OUTB,ATC-Towage (Outbound),TWG,ATH,ACT,CMPL,OUTB,TOWG,null,false,false,true,true,T-Towage-Outbound,jit1_1,null,null
+UC50,SOSP,CA,ATH,ACT,DEPA,OUTB,null,null,false,false,false,true,Special,jit1_1,null,null


### PR DESCRIPTION
With the rewrite of how we match timestamp definitions, we no longer
need the `canonicalTimestamp` column nor the `-ALT-X` timestamps.

Signed-off-by: Niels Thykier <nt@asseco.dk>