### PR TITLE
DDT-1241: Introduce is_vessel_draft_relevant

### DIFF
--- a/datamodel/initdb.d/05_reference_implementation_support.sql
+++ b/datamodel/initdb.d/05_reference_implementation_support.sql
@@ -560,6 +560,7 @@ CREATE TABLE dcsa_im_v3_0.timestamp_definition (
     port_call_part varchar(100) NOT NULL REFERENCES dcsa_im_v3_0.port_call_part (port_call_part),
     event_location_requirement varchar(10) NOT NULL CHECK (event_location_requirement IN ('EXCLUDED', 'OPTIONAL', 'REQUIRED')),
     is_terminal_needed boolean NOT NULL,
+    is_vessel_draft_relevant boolean NOT NULL,
     vessel_position_requirement varchar(10) NOT NULL CHECK (event_location_requirement IN ('EXCLUDED', 'OPTIONAL', 'REQUIRED')),
     is_miles_to_destination_relevant boolean NOT NULL,
     provided_in_standard text NOT NULL,

--- a/datamodel/samples.d/generate_timestampdefinitions.py
+++ b/datamodel/samples.d/generate_timestampdefinitions.py
@@ -484,6 +484,7 @@ FIELDS_ORDER = [
     'portCallPart',
     'eventLocationRequirement',
     'isTerminalNeeded',
+    'isVesselDraftRelevant',
     'vesselPositionRequirement',
     'isMilesToDestinationRelevant',
     'providedInStandard',
@@ -850,8 +851,9 @@ def generate_special_timestamp(
         vessel_position_requirement: str = EXCLUDED,
         event_location_requirement: str = EXCLUDED,
         negotiation_cycle: str = 'Special',
-        is_miles_to_destination_relevant=False,
-        implicit_variant_of : str = NULL_VALUE,
+        is_vessel_draft_relevant: bool = False,
+        is_miles_to_destination_relevant: bool = False,
+        implicit_variant_of: str = NULL_VALUE,
 ):
     _ensure_known(provided_in_standard, VALID_JIT_VERSIONS, "providedInStandard")
     _ensure_known(port_call_part, VALID_PORT_CALL_PARTS, "portCallPart")
@@ -877,6 +879,7 @@ def generate_special_timestamp(
         implicit_variant_of,  # implicitVariantOf
         is_pattern_timestamp=False,
         is_miles_to_destination_relevant=is_miles_to_destination_relevant,
+        is_vessel_draft_relevant=is_vessel_draft_relevant,
     )
 
 
@@ -929,6 +932,7 @@ def generic_xty_timestamps(
         implicit_implies_phase: Optional[str] = None,
         negotiation_cycle: Optional[str] = None,
         is_miles_to_destination_relevant: Union[bool, "GetItemProtocol[bool]"] = False,
+        is_vessel_draft_relevant: Union[bool, "GetItemProtocol[bool]"] = False,
 ):
 
     if implicit_implies_phase is None and len(port_call_phase_type_codes) == 2 \
@@ -952,6 +956,7 @@ def generic_xty_timestamps(
 
     initial_publisher_pattern = as_condition(initial_publisher_pattern)
     is_miles_to_destination_relevant = as_condition(is_miles_to_destination_relevant)
+    is_vessel_draft_relevant = as_condition(is_vessel_draft_relevant)
 
     if negotiation_cycle is None:
         negotiation_cycle_prefix = 'T-'
@@ -1046,6 +1051,7 @@ def generic_xty_timestamps(
         ts_event_location_requirement = event_location_requirement[timestamp_detail]
         ts_vessel_position_requirement = vessel_position_requirement[timestamp_detail]
         ts_is_miles_to_destination_relevant = is_miles_to_destination_relevant[timestamp_detail]
+        ts_is_vessel_draft_relevant = is_vessel_draft_relevant[timestamp_detail]
 
         _make_timestamp(
             full_name,
@@ -1064,6 +1070,7 @@ def generic_xty_timestamps(
             # 'CANC' does not follow the pattern.
             is_pattern_timestamp=timestamp_detail.operations_event_type_code != 'CANC',
             is_miles_to_destination_relevant=ts_is_miles_to_destination_relevant,
+            is_vessel_draft_relevant=ts_is_vessel_draft_relevant,
         )
 
 
@@ -1121,6 +1128,7 @@ def _make_timestamp(timestamp_name,
                     implicit_variant_of,
                     is_pattern_timestamp=False,
                     is_miles_to_destination_relevant=False,
+                    is_vessel_draft_relevant=False,
                     ):
 
     if timestamp_name in TS_NOT_IN_STANDARD:
@@ -1139,6 +1147,7 @@ def _make_timestamp(timestamp_name,
         port_call_part,  # Port Call Part
         event_location_requirement,
         facility_type_code == 'BRTH',  # isTerminalNeeded
+        is_vessel_draft_relevant,
         vessel_position_requirement,  # vesselPositionRequirement
         is_miles_to_destination_relevant,
         provided_in_standard,  # providedInStandard

--- a/datamodel/samples.d/generate_timestampdefinitions.py
+++ b/datamodel/samples.d/generate_timestampdefinitions.py
@@ -37,6 +37,7 @@ def declare_timestamps():
         event_location_requirement=event_classifier_code_matches(ifelse(REQ_PLN_ACT, REQUIRED, OPTIONAL)),
         negotiation_cycle='TA-Berth',
         is_miles_to_destination_relevant=event_classifier_code_matches(ifelse(EST_PLN, True, False)),
+        is_vessel_draft_relevant=event_classifier_code_matches(ifelse(EST_PLN_ACT, True, False)),
     )
 
     # ETS-Cargo Ops
@@ -131,6 +132,7 @@ def declare_timestamps():
         negotiation_cycle='TA-PBPL',
         # IFS says EST, PLN *and* ACT can use MtD
         is_miles_to_destination_relevant=event_classifier_code_matches(ifelse('REQ', False, True)),
+        is_vessel_draft_relevant=event_classifier_code_matches(ifelse(EST_PLN_ACT, True, False)),
     )
 
     # EOSP UC 34
@@ -144,6 +146,7 @@ def declare_timestamps():
         'jit1_1',
         vessel_position_requirement=OPTIONAL,
         is_miles_to_destination_relevant=True,
+        is_vessel_draft_relevant=True,
     )
 
     # AT All fast UC 42 + Gangway Down and Safe UC 43
@@ -174,6 +177,7 @@ def declare_timestamps():
             "Start Cargo Operations And Services",
             version,
             service_code,
+            is_vessel_draft_relevant=True,
             vessel_position_requirement=EXCLUDED,
             event_location_requirement=REQUIRED,
             implicit_variant_of=variant_of,
@@ -361,6 +365,7 @@ def declare_timestamps():
         ['OUTB', NULL_VALUE],
         "Port Departure Execution",
         'jit1_0',
+        is_vessel_draft_relevant=event_classifier_code_matches(ifelse(EST_PLN_ACT, True, False)),
         event_location_requirement=REQUIRED,
         negotiation_cycle='TD-Berth',
     )
@@ -387,6 +392,7 @@ def declare_timestamps():
         "Port Departure Execution",
         'jit1_1',
         NULL_VALUE,
+        is_vessel_draft_relevant=True,
         vessel_position_requirement=EXCLUDED,
         event_location_requirement=EXCLUDED,
     )
@@ -401,6 +407,7 @@ def declare_timestamps():
         "Other Services - Anchorage Planning And Execution",
         'jit1_2',
         event_location_requirement=event_classifier_code_matches(ifelse(EST_PLN_ACT, OPTIONAL, EXCLUDED)),
+        is_vessel_draft_relevant=event_classifier_code_matches(ifelse(EST_PLN_ACT, True, False)),
         vessel_position_requirement=OPTIONAL,
         # All except REQ has MtD in the IFS (even ATD-Anchorage, which seems weird)
         is_miles_to_destination_relevant=event_classifier_code_matches(ifelse('REQ', False, True)),

--- a/datamodel/samples.d/timestampdefinitions.csv
+++ b/datamodel/samples.d/timestampdefinitions.csv
@@ -1,213 +1,213 @@
-timestampID,timestampTypeName,eventClassifierCode,operationsEventTypeCode,portCallPhaseTypeCode,portCallServiceTypeCode,facilityTypeCode,portCallPart,eventLocationRequirement,isTerminalNeeded,vesselPositionRequirement,isMilesToDestinationRelevant,providedInStandard,acceptTimestampDefinition,rejectTimestampDefinition,negotiationCycle,implicitVariantOf
-ETA-Berth,ETA-Berth,EST,ARRI,INBD,null,BRTH,Berth Arrival Planning,OPTIONAL,True,OPTIONAL,True,jit1_1,RTA-Berth,RTA-Berth,TA-Berth,null
-ETA-Berth (<implicit>),ETA-Berth (<implicit>),EST,ARRI,null,null,BRTH,Berth Arrival Planning,OPTIONAL,True,OPTIONAL,True,jit1_0,RTA-Berth (<implicit>),RTA-Berth (<implicit>),TA-Berth,ETA-Berth
-RTA-Berth,RTA-Berth,REQ,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTA-Berth,ETA-Berth,TA-Berth,null
-RTA-Berth (<implicit>),RTA-Berth (<implicit>),REQ,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,EXCLUDED,False,jit1_0,PTA-Berth (<implicit>),ETA-Berth (<implicit>),TA-Berth,RTA-Berth
-PTA-Berth,PTA-Berth,PLN,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,OPTIONAL,True,jit1_1,null,null,TA-Berth,null
-PTA-Berth (<implicit>),PTA-Berth (<implicit>),PLN,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,OPTIONAL,True,jit1_0,null,null,TA-Berth,PTA-Berth
-ATA-Berth,ATA-Berth,ACT,ARRI,INBD,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,EXCLUDED,False,jit1_1,null,null,TA-Berth,null
-ATA-Berth (<implicit>),ATA-Berth (<implicit>),ACT,ARRI,null,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,EXCLUDED,False,jit1_0,null,null,TA-Berth,ATA-Berth
-ETS-Cargo Ops,ETS-Cargo Ops,EST,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,RTS-Cargo Ops,RTS-Cargo Ops,T-Cargo Ops,null
-RTS-Cargo Ops,RTS-Cargo Ops,REQ,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Cargo Ops,ETS-Cargo Ops,T-Cargo Ops,null
-PTS-Cargo Ops,PTS-Cargo Ops,PLN,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Cargo Ops,null
-ETS-Cargo Ops (<implicit>),ETS-Cargo Ops (<implicit>),EST,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,RTS-Cargo Ops (<implicit>),RTS-Cargo Ops (<implicit>),T-Cargo Ops,ETS-Cargo Ops
-RTS-Cargo Ops (<implicit>),RTS-Cargo Ops (<implicit>),REQ,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Cargo Ops (<implicit>),ETS-Cargo Ops (<implicit>),T-Cargo Ops,RTS-Cargo Ops
-PTS-Cargo Ops (<implicit>),PTS-Cargo Ops (<implicit>),PLN,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Cargo Ops,PTS-Cargo Ops
-ETS-Pilotage (Inbound),ETS-Pilotage (Inbound),EST,STRT,INBD,PILO,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,OPTIONAL,False,jit1_1,RTS-Pilotage (Inbound),RTS-Pilotage (Inbound),T-Pilotage (Inbound),null
-RTS-Pilotage (Inbound),RTS-Pilotage (Inbound),REQ,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_1,PTS-Pilotage (Inbound),ETS-Pilotage (Inbound),T-Pilotage (Inbound),null
-PTS-Pilotage (Inbound),PTS-Pilotage (Inbound),PLN,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
-ATS-Pilotage (Inbound),ATS-Pilotage (Inbound),ACT,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,OPTIONAL,True,jit1_1,null,null,T-Pilotage (Inbound),null
-ETC-Pilotage (Inbound),ETC-Pilotage (Inbound),EST,CMPL,INBD,PILO,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_1,RTC-Pilotage (Inbound),RTC-Pilotage (Inbound),T-Pilotage (Inbound),null
-RTC-Pilotage (Inbound),RTC-Pilotage (Inbound),REQ,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTC-Pilotage (Inbound),ETC-Pilotage (Inbound),T-Pilotage (Inbound),null
-PTC-Pilotage (Inbound),PTC-Pilotage (Inbound),PLN,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
-ATC-Pilotage (Inbound),ATC-Pilotage (Inbound),ACT,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
-Cancel Pilotage (Inbound),Cancel Pilotage (Inbound),ACT,CANC,INBD,PILO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Pilotage (Inbound),null
-ETS-Pilotage (<implicit>),ETS-Pilotage (<implicit>),EST,STRT,null,PILO,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,OPTIONAL,False,jit1_0,RTS-Pilotage (<implicit>),RTS-Pilotage (<implicit>),T-Pilotage (Inbound),ETS-Pilotage (Inbound)
-RTS-Pilotage (<implicit>),RTS-Pilotage (<implicit>),REQ,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_0,PTS-Pilotage (<implicit>),ETS-Pilotage (<implicit>),T-Pilotage (Inbound),RTS-Pilotage (Inbound)
-PTS-Pilotage (<implicit>),PTS-Pilotage (<implicit>),PLN,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),PTS-Pilotage (Inbound)
-ATS-Pilotage (<implicit>),ATS-Pilotage (<implicit>),ACT,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,OPTIONAL,True,jit1_0,null,null,T-Pilotage (Inbound),ATS-Pilotage (Inbound)
-ETC-Pilotage (<implicit>),ETC-Pilotage (<implicit>),EST,CMPL,null,PILO,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_0,RTC-Pilotage (<implicit>),RTC-Pilotage (<implicit>),T-Pilotage (Inbound),ETC-Pilotage (Inbound)
-RTC-Pilotage (<implicit>),RTC-Pilotage (<implicit>),REQ,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_0,PTC-Pilotage (<implicit>),ETC-Pilotage (<implicit>),T-Pilotage (Inbound),RTC-Pilotage (Inbound)
-PTC-Pilotage (<implicit>),PTC-Pilotage (<implicit>),PLN,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),PTC-Pilotage (Inbound)
-ATC-Pilotage (<implicit>),ATC-Pilotage (<implicit>),ACT,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),ATC-Pilotage (Inbound)
-ETS-Towage (Inbound),ETS-Towage (Inbound),EST,STRT,INBD,TOWG,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,OPTIONAL,False,jit1_1,RTS-Towage (Inbound),RTS-Towage (Inbound),T-Towage (Inbound),null
-RTS-Towage (Inbound),RTS-Towage (Inbound),REQ,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_1,PTS-Towage (Inbound),ETS-Towage (Inbound),T-Towage (Inbound),null
-PTS-Towage (Inbound),PTS-Towage (Inbound),PLN,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
-ATS-Towage (Inbound),ATS-Towage (Inbound),ACT,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,OPTIONAL,True,jit1_1,null,null,T-Towage (Inbound),null
-ETC-Towage (Inbound),ETC-Towage (Inbound),EST,CMPL,INBD,TOWG,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_1,RTC-Towage (Inbound),RTC-Towage (Inbound),T-Towage (Inbound),null
-RTC-Towage (Inbound),RTC-Towage (Inbound),REQ,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTC-Towage (Inbound),ETC-Towage (Inbound),T-Towage (Inbound),null
-PTC-Towage (Inbound),PTC-Towage (Inbound),PLN,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
-ATC-Towage (Inbound),ATC-Towage (Inbound),ACT,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
-Cancel Towage (Inbound),Cancel Towage (Inbound),ACT,CANC,INBD,TOWG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Towage (Inbound),null
-ETS-Towage (<implicit>),ETS-Towage (<implicit>),EST,STRT,null,TOWG,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,OPTIONAL,False,jit1_1,RTS-Towage (<implicit>),RTS-Towage (<implicit>),T-Towage (Inbound),ETS-Towage (Inbound)
-RTS-Towage (<implicit>),RTS-Towage (<implicit>),REQ,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_1,PTS-Towage (<implicit>),ETS-Towage (<implicit>),T-Towage (Inbound),RTS-Towage (Inbound)
-PTS-Towage (<implicit>),PTS-Towage (<implicit>),PLN,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),PTS-Towage (Inbound)
-ATS-Towage (<implicit>),ATS-Towage (<implicit>),ACT,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,OPTIONAL,True,jit1_1,null,null,T-Towage (Inbound),ATS-Towage (Inbound)
-ETC-Towage (<implicit>),ETC-Towage (<implicit>),EST,CMPL,null,TOWG,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_1,RTC-Towage (<implicit>),RTC-Towage (<implicit>),T-Towage (Inbound),ETC-Towage (Inbound)
-RTC-Towage (<implicit>),RTC-Towage (<implicit>),REQ,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_1,PTC-Towage (<implicit>),ETC-Towage (<implicit>),T-Towage (Inbound),RTC-Towage (Inbound)
-PTC-Towage (<implicit>),PTC-Towage (<implicit>),PLN,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),PTC-Towage (Inbound)
-ATC-Towage (<implicit>),ATC-Towage (<implicit>),ACT,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),ATC-Towage (Inbound)
-ETS-Mooring (Inbound),ETS-Mooring (Inbound),EST,STRT,INBD,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_2,RTS-Mooring (Inbound),RTS-Mooring (Inbound),T-Mooring (Inbound),null
-RTS-Mooring (Inbound),RTS-Mooring (Inbound),REQ,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTS-Mooring (Inbound),ETS-Mooring (Inbound),T-Mooring (Inbound),null
-PTS-Mooring (Inbound),PTS-Mooring (Inbound),PLN,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),null
-ATS-Mooring (Inbound),ATS-Mooring (Inbound),ACT,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
-ETC-Mooring (Inbound),ETC-Mooring (Inbound),EST,CMPL,INBD,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_2,RTC-Mooring (Inbound),RTC-Mooring (Inbound),T-Mooring (Inbound),null
-RTC-Mooring (Inbound),RTC-Mooring (Inbound),REQ,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTC-Mooring (Inbound),ETC-Mooring (Inbound),T-Mooring (Inbound),null
-PTC-Mooring (Inbound),PTC-Mooring (Inbound),PLN,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),null
-ATC-Mooring (Inbound),ATC-Mooring (Inbound),ACT,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
-Cancel Mooring (Inbound),Cancel Mooring (Inbound),ACT,CANC,INBD,MOOR,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
-ETS-Mooring (<implicit>),ETS-Mooring (<implicit>),EST,STRT,null,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_2,RTS-Mooring (<implicit>),RTS-Mooring (<implicit>),T-Mooring (Inbound),ETS-Mooring (Inbound)
-RTS-Mooring (<implicit>),RTS-Mooring (<implicit>),REQ,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTS-Mooring (<implicit>),ETS-Mooring (<implicit>),T-Mooring (Inbound),RTS-Mooring (Inbound)
-PTS-Mooring (<implicit>),PTS-Mooring (<implicit>),PLN,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),PTS-Mooring (Inbound)
-ATS-Mooring (<implicit>),ATS-Mooring (<implicit>),ACT,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),ATS-Mooring (Inbound)
-ETC-Mooring (<implicit>),ETC-Mooring (<implicit>),EST,CMPL,null,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,OPTIONAL,False,jit1_2,RTC-Mooring (<implicit>),RTC-Mooring (<implicit>),T-Mooring (Inbound),ETC-Mooring (Inbound)
-RTC-Mooring (<implicit>),RTC-Mooring (<implicit>),REQ,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTC-Mooring (<implicit>),ETC-Mooring (<implicit>),T-Mooring (Inbound),RTC-Mooring (Inbound)
-PTC-Mooring (<implicit>),PTC-Mooring (<implicit>),PLN,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),PTC-Mooring (Inbound)
-ATC-Mooring (<implicit>),ATC-Mooring (<implicit>),ACT,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),ATC-Mooring (Inbound)
-ETS-Bunkering@Anchorage,ETS-Bunkering@Anchorage,EST,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Anchorage,RTS-Bunkering@Anchorage,T-Bunkering,null
-ETS-Bunkering@Berth,ETS-Bunkering@Berth,EST,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,RTS-Bunkering@Berth,RTS-Bunkering@Berth,T-Bunkering,null
-RTS-Bunkering@Anchorage,RTS-Bunkering@Anchorage,REQ,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Anchorage,ETS-Bunkering@Anchorage,T-Bunkering,null
-RTS-Bunkering@Berth,RTS-Bunkering@Berth,REQ,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTS-Bunkering@Berth,ETS-Bunkering@Berth,T-Bunkering,null
-PTS-Bunkering@Anchorage,PTS-Bunkering@Anchorage,PLN,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-PTS-Bunkering@Berth,PTS-Bunkering@Berth,PLN,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-ETC-Bunkering@Anchorage,ETC-Bunkering@Anchorage,EST,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Anchorage,RTC-Bunkering@Anchorage,T-Bunkering,null
-ETC-Bunkering@Berth,ETC-Bunkering@Berth,EST,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,RTC-Bunkering@Berth,RTC-Bunkering@Berth,T-Bunkering,null
-RTC-Bunkering@Anchorage,RTC-Bunkering@Anchorage,REQ,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Anchorage,ETC-Bunkering@Anchorage,T-Bunkering,null
-RTC-Bunkering@Berth,RTC-Bunkering@Berth,REQ,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTC-Bunkering@Berth,ETC-Bunkering@Berth,T-Bunkering,null
-PTC-Bunkering@Anchorage,PTC-Bunkering@Anchorage,PLN,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-PTC-Bunkering@Berth,PTC-Bunkering@Berth,PLN,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-Cancel Bunkering@Anchorage,Cancel Bunkering@Anchorage,ACT,CANC,ALGS,BUNK,ANCH,OMIT Port Call Or Cancel A Service,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-Cancel Bunkering@Berth,Cancel Bunkering@Berth,ACT,CANC,ALGS,BUNK,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
-ETS-Bunkering@Anchorage (<implicit>),ETS-Bunkering@Anchorage (<implicit>),EST,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Anchorage (<implicit>),RTS-Bunkering@Anchorage (<implicit>),T-Bunkering,ETS-Bunkering@Anchorage
-ETS-Bunkering@Berth (<implicit>),ETS-Bunkering@Berth (<implicit>),EST,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,RTS-Bunkering@Berth (<implicit>),RTS-Bunkering@Berth (<implicit>),T-Bunkering,ETS-Bunkering@Berth
-RTS-Bunkering@Anchorage (<implicit>),RTS-Bunkering@Anchorage (<implicit>),REQ,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Anchorage (<implicit>),ETS-Bunkering@Anchorage (<implicit>),T-Bunkering,RTS-Bunkering@Anchorage
-RTS-Bunkering@Berth (<implicit>),RTS-Bunkering@Berth (<implicit>),REQ,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTS-Bunkering@Berth (<implicit>),ETS-Bunkering@Berth (<implicit>),T-Bunkering,RTS-Bunkering@Berth
-PTS-Bunkering@Anchorage (<implicit>),PTS-Bunkering@Anchorage (<implicit>),PLN,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTS-Bunkering@Anchorage
-PTS-Bunkering@Berth (<implicit>),PTS-Bunkering@Berth (<implicit>),PLN,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTS-Bunkering@Berth
-ETC-Bunkering@Anchorage (<implicit>),ETC-Bunkering@Anchorage (<implicit>),EST,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Anchorage (<implicit>),RTC-Bunkering@Anchorage (<implicit>),T-Bunkering,ETC-Bunkering@Anchorage
-ETC-Bunkering@Berth (<implicit>),ETC-Bunkering@Berth (<implicit>),EST,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,RTC-Bunkering@Berth (<implicit>),RTC-Bunkering@Berth (<implicit>),T-Bunkering,ETC-Bunkering@Berth
-RTC-Bunkering@Anchorage (<implicit>),RTC-Bunkering@Anchorage (<implicit>),REQ,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Anchorage (<implicit>),ETC-Bunkering@Anchorage (<implicit>),T-Bunkering,RTC-Bunkering@Anchorage
-RTC-Bunkering@Berth (<implicit>),RTC-Bunkering@Berth (<implicit>),REQ,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,PTC-Bunkering@Berth (<implicit>),ETC-Bunkering@Berth (<implicit>),T-Bunkering,RTC-Bunkering@Berth
-PTC-Bunkering@Anchorage (<implicit>),PTC-Bunkering@Anchorage (<implicit>),PLN,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Anchorage
-PTC-Bunkering@Berth (<implicit>),PTC-Bunkering@Berth (<implicit>),PLN,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Berth
-ETA-PBP,ETA-PBP,EST,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,RTA-PBP,RTA-PBP,TA-PBPL,null
-ETA-PBP (<implicit>),ETA-PBP (<implicit>),EST,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,RTA-PBP (<implicit>),RTA-PBP (<implicit>),TA-PBPL,ETA-PBP
-RTA-PBP,RTA-PBP,REQ,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,False,jit1_0,PTA-PBP,ETA-PBP,TA-PBPL,null
-RTA-PBP (<implicit>),RTA-PBP (<implicit>),REQ,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,False,jit1_0,PTA-PBP (<implicit>),ETA-PBP (<implicit>),TA-PBPL,RTA-PBP
-PTA-PBP,PTA-PBP,PLN,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
-PTA-PBP (<implicit>),PTA-PBP (<implicit>),PLN,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,PTA-PBP
-ATA-PBP,ATA-PBP,ACT,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
-ATA-PBP (<implicit>),ATA-PBP (<implicit>),ACT,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,ATA-PBP
-ESOP,ESOP,ACT,ARRI,INBD,null,null,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,False,OPTIONAL,True,jit1_1,null,null,Special,null
-AT All fast,AT All fast,ACT,ARRI,ALGS,FAST,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,EXCLUDED,False,jit1_1,null,null,Special,null
-Gangway Down and Safe,Gangway Down and Safe,ACT,ARRI,ALGS,GWAY,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,EXCLUDED,False,jit1_1,null,null,Special,null
-Vessel Readiness for Cargo operations,Vessel Readiness for Cargo operations,ACT,ARRI,ALGS,VRDY,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,Special,null
-Vessel Readiness for Cargo operations [JIT 1.1],Vessel Readiness for Cargo operations [JIT 1.1],ACT,ARRI,ALGS,SAFE,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,Special,Vessel Readiness for Cargo operations
-ATS-Cargo Ops,ATS-Cargo Ops,ACT,STRT,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,null
-ATS-Cargo Ops (<implicit>),ATS-Cargo Ops (<implicit>),ACT,STRT,null,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,ATS-Cargo Ops
-ATS-Cargo Ops Discharge,ATS-Cargo Ops Discharge,ACT,STRT,ALGS,DCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-ATC-Cargo Ops Discharge,ATC-Cargo Ops Discharge,ACT,CMPL,ALGS,DCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-ATS-Cargo Ops Load,ATS-Cargo Ops Load,ACT,STRT,ALGS,LCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-ETC-Cargo Ops,ETC-Cargo Ops,EST,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_2,RTC-Cargo Ops,RTC-Cargo Ops,T-Cargo Ops,null
-RTC-Cargo Ops,RTC-Cargo Ops,REQ,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_0,PTC-Cargo Ops,ETC-Cargo Ops,T-Cargo Ops,null
-PTC-Cargo Ops,PTC-Cargo Ops,PLN,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,null
-ATS-Bunkering@Anchorage,ATS-Bunkering@Anchorage,ACT,STRT,ALGS,BUNK,ANCH,Start Cargo Operations And Services,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
-ATS-Bunkering@Berth,ATS-Bunkering@Berth,ACT,STRT,ALGS,BUNK,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
-ATC-Bunkering@Anchorage,ATC-Bunkering@Anchorage,ACT,CMPL,ALGS,BUNK,ANCH,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
-ATC-Bunkering@Berth,ATC-Bunkering@Berth,ACT,CMPL,ALGS,BUNK,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
-ATS-Bunkering@Anchorage (<implicit>),ATS-Bunkering@Anchorage (<implicit>),ACT,STRT,null,BUNK,ANCH,Start Cargo Operations And Services,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATS-Bunkering@Anchorage
-ATS-Bunkering@Berth (<implicit>),ATS-Bunkering@Berth (<implicit>),ACT,STRT,null,BUNK,BRTH,Start Cargo Operations And Services,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATS-Bunkering@Berth
-ATC-Bunkering@Anchorage (<implicit>),ATC-Bunkering@Anchorage (<implicit>),ACT,CMPL,null,BUNK,ANCH,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATC-Bunkering@Anchorage
-ATC-Bunkering@Berth (<implicit>),ATC-Bunkering@Berth (<implicit>),ACT,CMPL,null,BUNK,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATC-Bunkering@Berth
-ETD-Berth,ETD-Berth,EST,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTD-Berth,RTD-Berth,TD-Berth,null
-ETD-Berth (<implicit>),ETD-Berth (<implicit>),EST,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_0,RTD-Berth (<implicit>),RTD-Berth (<implicit>),TD-Berth,ETD-Berth
-RTD-Berth,RTD-Berth,REQ,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTD-Berth,ETD-Berth,TD-Berth,null
-RTD-Berth (<implicit>),RTD-Berth (<implicit>),REQ,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_0,PTD-Berth (<implicit>),ETD-Berth (<implicit>),TD-Berth,RTD-Berth
-PTD-Berth,PTD-Berth,PLN,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,TD-Berth,null
-PTD-Berth (<implicit>),PTD-Berth (<implicit>),PLN,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,TD-Berth,PTD-Berth
-ETS-Pilotage (Outbound),ETS-Pilotage (Outbound),EST,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTS-Pilotage (Outbound),RTS-Pilotage (Outbound),T-Pilotage (Outbound),null
-RTS-Pilotage (Outbound),RTS-Pilotage (Outbound),REQ,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Pilotage (Outbound),ETS-Pilotage (Outbound),T-Pilotage (Outbound),null
-PTS-Pilotage (Outbound),PTS-Pilotage (Outbound),PLN,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
-ETC-Pilotage (Outbound),ETC-Pilotage (Outbound),EST,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,RTC-Pilotage (Outbound),RTC-Pilotage (Outbound),T-Pilotage (Outbound),null
-RTC-Pilotage (Outbound),RTC-Pilotage (Outbound),REQ,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,PTC-Pilotage (Outbound),ETC-Pilotage (Outbound),T-Pilotage (Outbound),null
-PTC-Pilotage (Outbound),PTC-Pilotage (Outbound),PLN,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
-Cancel Pilotage (Outbound),Cancel Pilotage (Outbound),ACT,CANC,OUTB,PILO,null,OMIT Port Call Or Cancel A Service,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Pilotage (Outbound),null
-ETS-Pilotage (Shifting),ETS-Pilotage (Shifting),EST,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTS-Pilotage (Shifting),RTS-Pilotage (Shifting),T-Pilotage (Shifting),null
-RTS-Pilotage (Shifting),RTS-Pilotage (Shifting),REQ,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Pilotage (Shifting),ETS-Pilotage (Shifting),T-Pilotage (Shifting),null
-PTS-Pilotage (Shifting),PTS-Pilotage (Shifting),PLN,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
-ETC-Pilotage (Shifting),ETC-Pilotage (Shifting),EST,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTC-Pilotage (Shifting),RTC-Pilotage (Shifting),T-Pilotage (Shifting),null
-RTC-Pilotage (Shifting),RTC-Pilotage (Shifting),REQ,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTC-Pilotage (Shifting),ETC-Pilotage (Shifting),T-Pilotage (Shifting),null
-PTC-Pilotage (Shifting),PTC-Pilotage (Shifting),PLN,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
-Cancel Pilotage (Shifting),Cancel Pilotage (Shifting),ACT,CANC,SHIF,PILO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Pilotage (Shifting),null
-ETS-Towage (Outbound),ETS-Towage (Outbound),EST,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTS-Towage (Outbound),RTS-Towage (Outbound),T-Towage (Outbound),null
-RTS-Towage (Outbound),RTS-Towage (Outbound),REQ,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Towage (Outbound),ETS-Towage (Outbound),T-Towage (Outbound),null
-PTS-Towage (Outbound),PTS-Towage (Outbound),PLN,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
-ETC-Towage (Outbound),ETC-Towage (Outbound),EST,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,RTC-Towage (Outbound),RTC-Towage (Outbound),T-Towage (Outbound),null
-RTC-Towage (Outbound),RTC-Towage (Outbound),REQ,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,PTC-Towage (Outbound),ETC-Towage (Outbound),T-Towage (Outbound),null
-PTC-Towage (Outbound),PTC-Towage (Outbound),PLN,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
-Cancel Towage (Outbound),Cancel Towage (Outbound),ACT,CANC,OUTB,TOWG,null,OMIT Port Call Or Cancel A Service,REQUIRED,False,EXCLUDED,False,jit1_2,null,null,T-Towage (Outbound),null
-ETS-Towage (Shifting),ETS-Towage (Shifting),EST,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTS-Towage (Shifting),RTS-Towage (Shifting),T-Towage (Shifting),null
-RTS-Towage (Shifting),RTS-Towage (Shifting),REQ,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTS-Towage (Shifting),ETS-Towage (Shifting),T-Towage (Shifting),null
-PTS-Towage (Shifting),PTS-Towage (Shifting),PLN,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
-ETC-Towage (Shifting),ETC-Towage (Shifting),EST,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,RTC-Towage (Shifting),RTC-Towage (Shifting),T-Towage (Shifting),null
-RTC-Towage (Shifting),RTC-Towage (Shifting),REQ,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,PTC-Towage (Shifting),ETC-Towage (Shifting),T-Towage (Shifting),null
-PTC-Towage (Shifting),PTC-Towage (Shifting),PLN,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
-Cancel Towage (Shifting),Cancel Towage (Shifting),ACT,CANC,SHIF,TOWG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Towage (Shifting),null
-ATC-Cargo Ops Load,ATC-Cargo Ops Load,ACT,CMPL,ALGS,LCRO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-ATC-Cargo Ops,ATC-Cargo Ops,ACT,CMPL,ALGS,CRGO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-Cancel Cargo Ops,Cancel Cargo Ops,ACT,CANC,ALGS,CRGO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
-ETS-Mooring (Outbound),ETS-Mooring (Outbound),EST,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,RTS-Mooring (Outbound),RTS-Mooring (Outbound),T-Mooring (Outbound),null
-RTS-Mooring (Outbound),RTS-Mooring (Outbound),REQ,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,PTS-Mooring (Outbound),ETS-Mooring (Outbound),T-Mooring (Outbound),null
-PTS-Mooring (Outbound),PTS-Mooring (Outbound),PLN,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
-ATS-Mooring (Outbound),ATS-Mooring (Outbound),ACT,STRT,OUTB,MOOR,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
-ETC-Mooring (Outbound),ETC-Mooring (Outbound),EST,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,RTC-Mooring (Outbound),RTC-Mooring (Outbound),T-Mooring (Outbound),null
-RTC-Mooring (Outbound),RTC-Mooring (Outbound),REQ,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,PTC-Mooring (Outbound),ETC-Mooring (Outbound),T-Mooring (Outbound),null
-PTC-Mooring (Outbound),PTC-Mooring (Outbound),PLN,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
-ATC-Mooring (Outbound),ATC-Mooring (Outbound),ACT,CMPL,OUTB,MOOR,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
-Cancel Mooring (Outbound),Cancel Mooring (Outbound),ACT,CANC,OUTB,MOOR,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
-ATC Lashing,ATC Lashing,ACT,CMPL,ALGS,LASH,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,Special,null
-Terminal Ready for vessel departure,Terminal Ready for vessel departure,ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,Special,null
-Vessel Ready to sail,Vessel Ready to sail,ACT,DEPA,ALGS,VRDY,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,Special,null
-Vessel Ready to sail [JIT 1.1],Vessel Ready to sail [JIT 1.1],ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,Special,Vessel Ready to sail
-ATD-Berth,ATD-Berth,ACT,DEPA,OUTB,null,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,TD-Berth,null
-ATD-Berth (<implicit>),ATD-Berth (<implicit>),ACT,DEPA,null,null,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_0,null,null,TD-Berth,ATD-Berth
-ATS-Pilotage (Outbound),ATS-Pilotage (Outbound),ACT,STRT,OUTB,PILO,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
-ATC-Pilotage (Outbound),ATC-Pilotage (Outbound),ACT,CMPL,OUTB,PILO,null,Port Departure Execution,EXCLUDED,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
-ATS-Pilotage (Shifting),ATS-Pilotage (Shifting),ACT,STRT,SHIF,PILO,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
-ATC-Pilotage (Shifting),ATC-Pilotage (Shifting),ACT,CMPL,SHIF,PILO,BRTH,Port Departure Execution,EXCLUDED,True,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
-ATS-Towage (Outbound),ATS-Towage (Outbound),ACT,STRT,OUTB,TOWG,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
-ATC-Towage (Outbound),ATC-Towage (Outbound),ACT,CMPL,OUTB,TOWG,null,Port Departure Execution,EXCLUDED,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
-ATS-Towage (Shifting),ATS-Towage (Shifting),ACT,STRT,SHIF,TOWG,BRTH,Port Departure Execution,REQUIRED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
-ATC-Towage (Shifting),ATC-Towage (Shifting),ACT,CMPL,SHIF,TOWG,BRTH,Port Departure Execution,EXCLUDED,True,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
-SOSP,SOSP,ACT,DEPA,OUTB,null,null,Port Departure Execution,EXCLUDED,False,EXCLUDED,False,jit1_1,null,null,Special,null
-ETA-Anchorage,ETA-Anchorage,EST,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,RTA-Anchorage,RTA-Anchorage,T-Anchorage,null
-ETD-Anchorage,ETD-Anchorage,EST,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,RTD-Anchorage,RTD-Anchorage,T-Anchorage,null
-RTA-Anchorage,RTA-Anchorage,REQ,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,OPTIONAL,False,jit1_2,PTA-Anchorage,ETA-Anchorage,T-Anchorage,null
-RTD-Anchorage,RTD-Anchorage,REQ,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,OPTIONAL,False,jit1_2,PTD-Anchorage,ETD-Anchorage,T-Anchorage,null
-PTA-Anchorage,PTA-Anchorage,PLN,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-PTD-Anchorage,PTD-Anchorage,PLN,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATA-Anchorage,ATA-Anchorage,ACT,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATD-Anchorage,ATD-Anchorage,ACT,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATS-Anchorage Ops,ATS-Anchorage Ops,ACT,STRT,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATC-Anchorage Ops,ATC-Anchorage Ops,ACT,CMPL,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ETS-Sludge@Anchorage,ETS-Sludge@Anchorage,EST,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,RTS-Sludge@Anchorage,RTS-Sludge@Anchorage,T-Sludge,null
-ETS-Sludge@Berth,ETS-Sludge@Berth,EST,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,RTS-Sludge@Berth,RTS-Sludge@Berth,T-Sludge,null
-PTS-Sludge@Anchorage,PTS-Sludge@Anchorage,PLN,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-PTS-Sludge@Berth,PTS-Sludge@Berth,PLN,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-RTS-Sludge@Anchorage,RTS-Sludge@Anchorage,REQ,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,PTS-Sludge@Anchorage,ETS-Sludge@Anchorage,T-Sludge,null
-RTS-Sludge@Berth,RTS-Sludge@Berth,REQ,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,PTS-Sludge@Berth,ETS-Sludge@Berth,T-Sludge,null
-ATS-Sludge@Anchorage,ATS-Sludge@Anchorage,ACT,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-ATS-Sludge@Berth,ATS-Sludge@Berth,ACT,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-ETC-Sludge@Anchorage,ETC-Sludge@Anchorage,EST,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,RTC-Sludge@Anchorage,RTC-Sludge@Anchorage,T-Sludge,null
-ETC-Sludge@Berth,ETC-Sludge@Berth,EST,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,RTC-Sludge@Berth,RTC-Sludge@Berth,T-Sludge,null
-PTC-Sludge@Anchorage,PTC-Sludge@Anchorage,PLN,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-PTC-Sludge@Berth,PTC-Sludge@Berth,PLN,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-RTC-Sludge@Anchorage,RTC-Sludge@Anchorage,REQ,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,PTC-Sludge@Anchorage,ETC-Sludge@Anchorage,T-Sludge,null
-RTC-Sludge@Berth,RTC-Sludge@Berth,REQ,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,PTC-Sludge@Berth,ETC-Sludge@Berth,T-Sludge,null
-ATC-Sludge@Anchorage,ATC-Sludge@Anchorage,ACT,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-ATC-Sludge@Berth,ATC-Sludge@Berth,ACT,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-Cancel Sludge@Anchorage,Cancel Sludge@Anchorage,ACT,CANC,null,SLUG,ANCH,OMIT Port Call Or Cancel A Service,REQUIRED,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-Cancel Sludge@Berth,Cancel Sludge@Berth,ACT,CANC,null,SLUG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
-ATS-Shore Power,ATS-Shore Power,ACT,STRT,ALGS,SHPW,BRTH,Other Services - Shore Power Execution,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Shore Power,null
-ATC-Shore Power,ATC-Shore Power,ACT,CMPL,ALGS,SHPW,BRTH,Other Services - Shore Power Execution,REQUIRED,True,EXCLUDED,False,jit1_2,null,null,T-Shore Power,null
-Omit Port Call,Omit Port Call,ACT,OMIT,null,null,null,OMIT Port Call Or Cancel A Service,EXCLUDED,False,OPTIONAL,False,jit1_2,null,null,Special,null
+timestampID,timestampTypeName,eventClassifierCode,operationsEventTypeCode,portCallPhaseTypeCode,portCallServiceTypeCode,facilityTypeCode,portCallPart,eventLocationRequirement,isTerminalNeeded,isVesselDraftRelevant,vesselPositionRequirement,isMilesToDestinationRelevant,providedInStandard,acceptTimestampDefinition,rejectTimestampDefinition,negotiationCycle,implicitVariantOf
+ETA-Berth,ETA-Berth,EST,ARRI,INBD,null,BRTH,Berth Arrival Planning,OPTIONAL,True,False,OPTIONAL,True,jit1_1,RTA-Berth,RTA-Berth,TA-Berth,null
+ETA-Berth (<implicit>),ETA-Berth (<implicit>),EST,ARRI,null,null,BRTH,Berth Arrival Planning,OPTIONAL,True,False,OPTIONAL,True,jit1_0,RTA-Berth (<implicit>),RTA-Berth (<implicit>),TA-Berth,ETA-Berth
+RTA-Berth,RTA-Berth,REQ,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTA-Berth,ETA-Berth,TA-Berth,null
+RTA-Berth (<implicit>),RTA-Berth (<implicit>),REQ,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,EXCLUDED,False,jit1_0,PTA-Berth (<implicit>),ETA-Berth (<implicit>),TA-Berth,RTA-Berth
+PTA-Berth,PTA-Berth,PLN,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,OPTIONAL,True,jit1_1,null,null,TA-Berth,null
+PTA-Berth (<implicit>),PTA-Berth (<implicit>),PLN,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,OPTIONAL,True,jit1_0,null,null,TA-Berth,PTA-Berth
+ATA-Berth,ATA-Berth,ACT,ARRI,INBD,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,TA-Berth,null
+ATA-Berth (<implicit>),ATA-Berth (<implicit>),ACT,ARRI,null,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TA-Berth,ATA-Berth
+ETS-Cargo Ops,ETS-Cargo Ops,EST,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,RTS-Cargo Ops,RTS-Cargo Ops,T-Cargo Ops,null
+RTS-Cargo Ops,RTS-Cargo Ops,REQ,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Cargo Ops,ETS-Cargo Ops,T-Cargo Ops,null
+PTS-Cargo Ops,PTS-Cargo Ops,PLN,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Cargo Ops,null
+ETS-Cargo Ops (<implicit>),ETS-Cargo Ops (<implicit>),EST,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,RTS-Cargo Ops (<implicit>),RTS-Cargo Ops (<implicit>),T-Cargo Ops,ETS-Cargo Ops
+RTS-Cargo Ops (<implicit>),RTS-Cargo Ops (<implicit>),REQ,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Cargo Ops (<implicit>),ETS-Cargo Ops (<implicit>),T-Cargo Ops,RTS-Cargo Ops
+PTS-Cargo Ops (<implicit>),PTS-Cargo Ops (<implicit>),PLN,STRT,null,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Cargo Ops,PTS-Cargo Ops
+ETS-Pilotage (Inbound),ETS-Pilotage (Inbound),EST,STRT,INBD,PILO,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,OPTIONAL,False,jit1_1,RTS-Pilotage (Inbound),RTS-Pilotage (Inbound),T-Pilotage (Inbound),null
+RTS-Pilotage (Inbound),RTS-Pilotage (Inbound),REQ,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_1,PTS-Pilotage (Inbound),ETS-Pilotage (Inbound),T-Pilotage (Inbound),null
+PTS-Pilotage (Inbound),PTS-Pilotage (Inbound),PLN,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
+ATS-Pilotage (Inbound),ATS-Pilotage (Inbound),ACT,STRT,INBD,PILO,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,True,jit1_1,null,null,T-Pilotage (Inbound),null
+ETC-Pilotage (Inbound),ETC-Pilotage (Inbound),EST,CMPL,INBD,PILO,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_1,RTC-Pilotage (Inbound),RTC-Pilotage (Inbound),T-Pilotage (Inbound),null
+RTC-Pilotage (Inbound),RTC-Pilotage (Inbound),REQ,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTC-Pilotage (Inbound),ETC-Pilotage (Inbound),T-Pilotage (Inbound),null
+PTC-Pilotage (Inbound),PTC-Pilotage (Inbound),PLN,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
+ATC-Pilotage (Inbound),ATC-Pilotage (Inbound),ACT,CMPL,INBD,PILO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Pilotage (Inbound),null
+Cancel Pilotage (Inbound),Cancel Pilotage (Inbound),ACT,CANC,INBD,PILO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Pilotage (Inbound),null
+ETS-Pilotage (<implicit>),ETS-Pilotage (<implicit>),EST,STRT,null,PILO,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,OPTIONAL,False,jit1_0,RTS-Pilotage (<implicit>),RTS-Pilotage (<implicit>),T-Pilotage (Inbound),ETS-Pilotage (Inbound)
+RTS-Pilotage (<implicit>),RTS-Pilotage (<implicit>),REQ,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_0,PTS-Pilotage (<implicit>),ETS-Pilotage (<implicit>),T-Pilotage (Inbound),RTS-Pilotage (Inbound)
+PTS-Pilotage (<implicit>),PTS-Pilotage (<implicit>),PLN,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),PTS-Pilotage (Inbound)
+ATS-Pilotage (<implicit>),ATS-Pilotage (<implicit>),ACT,STRT,null,PILO,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,True,jit1_0,null,null,T-Pilotage (Inbound),ATS-Pilotage (Inbound)
+ETC-Pilotage (<implicit>),ETC-Pilotage (<implicit>),EST,CMPL,null,PILO,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_0,RTC-Pilotage (<implicit>),RTC-Pilotage (<implicit>),T-Pilotage (Inbound),ETC-Pilotage (Inbound)
+RTC-Pilotage (<implicit>),RTC-Pilotage (<implicit>),REQ,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_0,PTC-Pilotage (<implicit>),ETC-Pilotage (<implicit>),T-Pilotage (Inbound),RTC-Pilotage (Inbound)
+PTC-Pilotage (<implicit>),PTC-Pilotage (<implicit>),PLN,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),PTC-Pilotage (Inbound)
+ATC-Pilotage (<implicit>),ATC-Pilotage (<implicit>),ACT,CMPL,null,PILO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_0,null,null,T-Pilotage (Inbound),ATC-Pilotage (Inbound)
+ETS-Towage (Inbound),ETS-Towage (Inbound),EST,STRT,INBD,TOWG,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,OPTIONAL,False,jit1_1,RTS-Towage (Inbound),RTS-Towage (Inbound),T-Towage (Inbound),null
+RTS-Towage (Inbound),RTS-Towage (Inbound),REQ,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_1,PTS-Towage (Inbound),ETS-Towage (Inbound),T-Towage (Inbound),null
+PTS-Towage (Inbound),PTS-Towage (Inbound),PLN,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
+ATS-Towage (Inbound),ATS-Towage (Inbound),ACT,STRT,INBD,TOWG,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,True,jit1_1,null,null,T-Towage (Inbound),null
+ETC-Towage (Inbound),ETC-Towage (Inbound),EST,CMPL,INBD,TOWG,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_1,RTC-Towage (Inbound),RTC-Towage (Inbound),T-Towage (Inbound),null
+RTC-Towage (Inbound),RTC-Towage (Inbound),REQ,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTC-Towage (Inbound),ETC-Towage (Inbound),T-Towage (Inbound),null
+PTC-Towage (Inbound),PTC-Towage (Inbound),PLN,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
+ATC-Towage (Inbound),ATC-Towage (Inbound),ACT,CMPL,INBD,TOWG,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),null
+Cancel Towage (Inbound),Cancel Towage (Inbound),ACT,CANC,INBD,TOWG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Towage (Inbound),null
+ETS-Towage (<implicit>),ETS-Towage (<implicit>),EST,STRT,null,TOWG,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,OPTIONAL,False,jit1_1,RTS-Towage (<implicit>),RTS-Towage (<implicit>),T-Towage (Inbound),ETS-Towage (Inbound)
+RTS-Towage (<implicit>),RTS-Towage (<implicit>),REQ,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_1,PTS-Towage (<implicit>),ETS-Towage (<implicit>),T-Towage (Inbound),RTS-Towage (Inbound)
+PTS-Towage (<implicit>),PTS-Towage (<implicit>),PLN,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),PTS-Towage (Inbound)
+ATS-Towage (<implicit>),ATS-Towage (<implicit>),ACT,STRT,null,TOWG,PBPL,Services Planning,REQUIRED,False,False,OPTIONAL,True,jit1_1,null,null,T-Towage (Inbound),ATS-Towage (Inbound)
+ETC-Towage (<implicit>),ETC-Towage (<implicit>),EST,CMPL,null,TOWG,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_1,RTC-Towage (<implicit>),RTC-Towage (<implicit>),T-Towage (Inbound),ETC-Towage (Inbound)
+RTC-Towage (<implicit>),RTC-Towage (<implicit>),REQ,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTC-Towage (<implicit>),ETC-Towage (<implicit>),T-Towage (Inbound),RTC-Towage (Inbound)
+PTC-Towage (<implicit>),PTC-Towage (<implicit>),PLN,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),PTC-Towage (Inbound)
+ATC-Towage (<implicit>),ATC-Towage (<implicit>),ACT,CMPL,null,TOWG,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Towage (Inbound),ATC-Towage (Inbound)
+ETS-Mooring (Inbound),ETS-Mooring (Inbound),EST,STRT,INBD,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_2,RTS-Mooring (Inbound),RTS-Mooring (Inbound),T-Mooring (Inbound),null
+RTS-Mooring (Inbound),RTS-Mooring (Inbound),REQ,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTS-Mooring (Inbound),ETS-Mooring (Inbound),T-Mooring (Inbound),null
+PTS-Mooring (Inbound),PTS-Mooring (Inbound),PLN,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),null
+ATS-Mooring (Inbound),ATS-Mooring (Inbound),ACT,STRT,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
+ETC-Mooring (Inbound),ETC-Mooring (Inbound),EST,CMPL,INBD,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_2,RTC-Mooring (Inbound),RTC-Mooring (Inbound),T-Mooring (Inbound),null
+RTC-Mooring (Inbound),RTC-Mooring (Inbound),REQ,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Mooring (Inbound),ETC-Mooring (Inbound),T-Mooring (Inbound),null
+PTC-Mooring (Inbound),PTC-Mooring (Inbound),PLN,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),null
+ATC-Mooring (Inbound),ATC-Mooring (Inbound),ACT,CMPL,INBD,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
+Cancel Mooring (Inbound),Cancel Mooring (Inbound),ACT,CANC,INBD,MOOR,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),null
+ETS-Mooring (<implicit>),ETS-Mooring (<implicit>),EST,STRT,null,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_2,RTS-Mooring (<implicit>),RTS-Mooring (<implicit>),T-Mooring (Inbound),ETS-Mooring (Inbound)
+RTS-Mooring (<implicit>),RTS-Mooring (<implicit>),REQ,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTS-Mooring (<implicit>),ETS-Mooring (<implicit>),T-Mooring (Inbound),RTS-Mooring (Inbound)
+PTS-Mooring (<implicit>),PTS-Mooring (<implicit>),PLN,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),PTS-Mooring (Inbound)
+ATS-Mooring (<implicit>),ATS-Mooring (<implicit>),ACT,STRT,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),ATS-Mooring (Inbound)
+ETC-Mooring (<implicit>),ETC-Mooring (<implicit>),EST,CMPL,null,MOOR,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,OPTIONAL,False,jit1_2,RTC-Mooring (<implicit>),RTC-Mooring (<implicit>),T-Mooring (Inbound),ETC-Mooring (Inbound)
+RTC-Mooring (<implicit>),RTC-Mooring (<implicit>),REQ,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Mooring (<implicit>),ETC-Mooring (<implicit>),T-Mooring (Inbound),RTC-Mooring (Inbound)
+PTC-Mooring (<implicit>),PTC-Mooring (<implicit>),PLN,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Mooring (Inbound),PTC-Mooring (Inbound)
+ATC-Mooring (<implicit>),ATC-Mooring (<implicit>),ACT,CMPL,null,MOOR,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Inbound),ATC-Mooring (Inbound)
+ETS-Bunkering@Anchorage,ETS-Bunkering@Anchorage,EST,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Anchorage,RTS-Bunkering@Anchorage,T-Bunkering,null
+ETS-Bunkering@Berth,ETS-Bunkering@Berth,EST,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Berth,RTS-Bunkering@Berth,T-Bunkering,null
+RTS-Bunkering@Anchorage,RTS-Bunkering@Anchorage,REQ,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Anchorage,ETS-Bunkering@Anchorage,T-Bunkering,null
+RTS-Bunkering@Berth,RTS-Bunkering@Berth,REQ,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Berth,ETS-Bunkering@Berth,T-Bunkering,null
+PTS-Bunkering@Anchorage,PTS-Bunkering@Anchorage,PLN,STRT,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+PTS-Bunkering@Berth,PTS-Bunkering@Berth,PLN,STRT,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+ETC-Bunkering@Anchorage,ETC-Bunkering@Anchorage,EST,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Anchorage,RTC-Bunkering@Anchorage,T-Bunkering,null
+ETC-Bunkering@Berth,ETC-Bunkering@Berth,EST,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Berth,RTC-Bunkering@Berth,T-Bunkering,null
+RTC-Bunkering@Anchorage,RTC-Bunkering@Anchorage,REQ,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Anchorage,ETC-Bunkering@Anchorage,T-Bunkering,null
+RTC-Bunkering@Berth,RTC-Bunkering@Berth,REQ,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Berth,ETC-Bunkering@Berth,T-Bunkering,null
+PTC-Bunkering@Anchorage,PTC-Bunkering@Anchorage,PLN,CMPL,ALGS,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+PTC-Bunkering@Berth,PTC-Bunkering@Berth,PLN,CMPL,ALGS,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+Cancel Bunkering@Anchorage,Cancel Bunkering@Anchorage,ACT,CANC,ALGS,BUNK,ANCH,OMIT Port Call Or Cancel A Service,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+Cancel Bunkering@Berth,Cancel Bunkering@Berth,ACT,CANC,ALGS,BUNK,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,null
+ETS-Bunkering@Anchorage (<implicit>),ETS-Bunkering@Anchorage (<implicit>),EST,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Anchorage (<implicit>),RTS-Bunkering@Anchorage (<implicit>),T-Bunkering,ETS-Bunkering@Anchorage
+ETS-Bunkering@Berth (<implicit>),ETS-Bunkering@Berth (<implicit>),EST,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTS-Bunkering@Berth (<implicit>),RTS-Bunkering@Berth (<implicit>),T-Bunkering,ETS-Bunkering@Berth
+RTS-Bunkering@Anchorage (<implicit>),RTS-Bunkering@Anchorage (<implicit>),REQ,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Anchorage (<implicit>),ETS-Bunkering@Anchorage (<implicit>),T-Bunkering,RTS-Bunkering@Anchorage
+RTS-Bunkering@Berth (<implicit>),RTS-Bunkering@Berth (<implicit>),REQ,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTS-Bunkering@Berth (<implicit>),ETS-Bunkering@Berth (<implicit>),T-Bunkering,RTS-Bunkering@Berth
+PTS-Bunkering@Anchorage (<implicit>),PTS-Bunkering@Anchorage (<implicit>),PLN,STRT,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTS-Bunkering@Anchorage
+PTS-Bunkering@Berth (<implicit>),PTS-Bunkering@Berth (<implicit>),PLN,STRT,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTS-Bunkering@Berth
+ETC-Bunkering@Anchorage (<implicit>),ETC-Bunkering@Anchorage (<implicit>),EST,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Anchorage (<implicit>),RTC-Bunkering@Anchorage (<implicit>),T-Bunkering,ETC-Bunkering@Anchorage
+ETC-Bunkering@Berth (<implicit>),ETC-Bunkering@Berth (<implicit>),EST,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTC-Bunkering@Berth (<implicit>),RTC-Bunkering@Berth (<implicit>),T-Bunkering,ETC-Bunkering@Berth
+RTC-Bunkering@Anchorage (<implicit>),RTC-Bunkering@Anchorage (<implicit>),REQ,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Anchorage (<implicit>),ETC-Bunkering@Anchorage (<implicit>),T-Bunkering,RTC-Bunkering@Anchorage
+RTC-Bunkering@Berth (<implicit>),RTC-Bunkering@Berth (<implicit>),REQ,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Berth (<implicit>),ETC-Bunkering@Berth (<implicit>),T-Bunkering,RTC-Bunkering@Berth
+PTC-Bunkering@Anchorage (<implicit>),PTC-Bunkering@Anchorage (<implicit>),PLN,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Anchorage
+PTC-Bunkering@Berth (<implicit>),PTC-Bunkering@Berth (<implicit>),PLN,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Berth
+ETA-PBP,ETA-PBP,EST,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,RTA-PBP,RTA-PBP,TA-PBPL,null
+ETA-PBP (<implicit>),ETA-PBP (<implicit>),EST,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,RTA-PBP (<implicit>),RTA-PBP (<implicit>),TA-PBPL,ETA-PBP
+RTA-PBP,RTA-PBP,REQ,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,False,jit1_0,PTA-PBP,ETA-PBP,TA-PBPL,null
+RTA-PBP (<implicit>),RTA-PBP (<implicit>),REQ,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,False,jit1_0,PTA-PBP (<implicit>),ETA-PBP (<implicit>),TA-PBPL,RTA-PBP
+PTA-PBP,PTA-PBP,PLN,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
+PTA-PBP (<implicit>),PTA-PBP (<implicit>),PLN,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,PTA-PBP
+ATA-PBP,ATA-PBP,ACT,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
+ATA-PBP (<implicit>),ATA-PBP (<implicit>),ACT,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,ATA-PBP
+ESOP,ESOP,ACT,ARRI,INBD,null,null,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,False,False,OPTIONAL,True,jit1_1,null,null,Special,null
+AT All fast,AT All fast,ACT,ARRI,ALGS,FAST,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
+Gangway Down and Safe,Gangway Down and Safe,ACT,ARRI,ALGS,GWAY,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
+Vessel Readiness for Cargo operations,Vessel Readiness for Cargo operations,ACT,ARRI,ALGS,VRDY,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,Special,null
+Vessel Readiness for Cargo operations [JIT 1.1],Vessel Readiness for Cargo operations [JIT 1.1],ACT,ARRI,ALGS,SAFE,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,Vessel Readiness for Cargo operations
+ATS-Cargo Ops,ATS-Cargo Ops,ACT,STRT,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,null
+ATS-Cargo Ops (<implicit>),ATS-Cargo Ops (<implicit>),ACT,STRT,null,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,ATS-Cargo Ops
+ATS-Cargo Ops Discharge,ATS-Cargo Ops Discharge,ACT,STRT,ALGS,DCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+ATC-Cargo Ops Discharge,ATC-Cargo Ops Discharge,ACT,CMPL,ALGS,DCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+ATS-Cargo Ops Load,ATS-Cargo Ops Load,ACT,STRT,ALGS,LCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+ETC-Cargo Ops,ETC-Cargo Ops,EST,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTC-Cargo Ops,RTC-Cargo Ops,T-Cargo Ops,null
+RTC-Cargo Ops,RTC-Cargo Ops,REQ,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,PTC-Cargo Ops,ETC-Cargo Ops,T-Cargo Ops,null
+PTC-Cargo Ops,PTC-Cargo Ops,PLN,CMPL,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,null
+ATS-Bunkering@Anchorage,ATS-Bunkering@Anchorage,ACT,STRT,ALGS,BUNK,ANCH,Start Cargo Operations And Services,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
+ATS-Bunkering@Berth,ATS-Bunkering@Berth,ACT,STRT,ALGS,BUNK,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
+ATC-Bunkering@Anchorage,ATC-Bunkering@Anchorage,ACT,CMPL,ALGS,BUNK,ANCH,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
+ATC-Bunkering@Berth,ATC-Bunkering@Berth,ACT,CMPL,ALGS,BUNK,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,null
+ATS-Bunkering@Anchorage (<implicit>),ATS-Bunkering@Anchorage (<implicit>),ACT,STRT,null,BUNK,ANCH,Start Cargo Operations And Services,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATS-Bunkering@Anchorage
+ATS-Bunkering@Berth (<implicit>),ATS-Bunkering@Berth (<implicit>),ACT,STRT,null,BUNK,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATS-Bunkering@Berth
+ATC-Bunkering@Anchorage (<implicit>),ATC-Bunkering@Anchorage (<implicit>),ACT,CMPL,null,BUNK,ANCH,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATC-Bunkering@Anchorage
+ATC-Bunkering@Berth (<implicit>),ATC-Bunkering@Berth (<implicit>),ACT,CMPL,null,BUNK,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Bunkering,ATC-Bunkering@Berth
+ETD-Berth,ETD-Berth,EST,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTD-Berth,RTD-Berth,TD-Berth,null
+ETD-Berth (<implicit>),ETD-Berth (<implicit>),EST,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_0,RTD-Berth (<implicit>),RTD-Berth (<implicit>),TD-Berth,ETD-Berth
+RTD-Berth,RTD-Berth,REQ,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTD-Berth,ETD-Berth,TD-Berth,null
+RTD-Berth (<implicit>),RTD-Berth (<implicit>),REQ,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_0,PTD-Berth (<implicit>),ETD-Berth (<implicit>),TD-Berth,RTD-Berth
+PTD-Berth,PTD-Berth,PLN,DEPA,ALGS,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,TD-Berth,null
+PTD-Berth (<implicit>),PTD-Berth (<implicit>),PLN,DEPA,null,null,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TD-Berth,PTD-Berth
+ETS-Pilotage (Outbound),ETS-Pilotage (Outbound),EST,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTS-Pilotage (Outbound),RTS-Pilotage (Outbound),T-Pilotage (Outbound),null
+RTS-Pilotage (Outbound),RTS-Pilotage (Outbound),REQ,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Pilotage (Outbound),ETS-Pilotage (Outbound),T-Pilotage (Outbound),null
+PTS-Pilotage (Outbound),PTS-Pilotage (Outbound),PLN,STRT,OUTB,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
+ETC-Pilotage (Outbound),ETC-Pilotage (Outbound),EST,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,RTC-Pilotage (Outbound),RTC-Pilotage (Outbound),T-Pilotage (Outbound),null
+RTC-Pilotage (Outbound),RTC-Pilotage (Outbound),REQ,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,PTC-Pilotage (Outbound),ETC-Pilotage (Outbound),T-Pilotage (Outbound),null
+PTC-Pilotage (Outbound),PTC-Pilotage (Outbound),PLN,CMPL,OUTB,PILO,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
+Cancel Pilotage (Outbound),Cancel Pilotage (Outbound),ACT,CANC,OUTB,PILO,null,OMIT Port Call Or Cancel A Service,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Pilotage (Outbound),null
+ETS-Pilotage (Shifting),ETS-Pilotage (Shifting),EST,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTS-Pilotage (Shifting),RTS-Pilotage (Shifting),T-Pilotage (Shifting),null
+RTS-Pilotage (Shifting),RTS-Pilotage (Shifting),REQ,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Pilotage (Shifting),ETS-Pilotage (Shifting),T-Pilotage (Shifting),null
+PTS-Pilotage (Shifting),PTS-Pilotage (Shifting),PLN,STRT,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
+ETC-Pilotage (Shifting),ETC-Pilotage (Shifting),EST,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTC-Pilotage (Shifting),RTC-Pilotage (Shifting),T-Pilotage (Shifting),null
+RTC-Pilotage (Shifting),RTC-Pilotage (Shifting),REQ,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTC-Pilotage (Shifting),ETC-Pilotage (Shifting),T-Pilotage (Shifting),null
+PTC-Pilotage (Shifting),PTC-Pilotage (Shifting),PLN,CMPL,SHIF,PILO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
+Cancel Pilotage (Shifting),Cancel Pilotage (Shifting),ACT,CANC,SHIF,PILO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Pilotage (Shifting),null
+ETS-Towage (Outbound),ETS-Towage (Outbound),EST,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTS-Towage (Outbound),RTS-Towage (Outbound),T-Towage (Outbound),null
+RTS-Towage (Outbound),RTS-Towage (Outbound),REQ,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Towage (Outbound),ETS-Towage (Outbound),T-Towage (Outbound),null
+PTS-Towage (Outbound),PTS-Towage (Outbound),PLN,STRT,OUTB,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
+ETC-Towage (Outbound),ETC-Towage (Outbound),EST,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,RTC-Towage (Outbound),RTC-Towage (Outbound),T-Towage (Outbound),null
+RTC-Towage (Outbound),RTC-Towage (Outbound),REQ,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,PTC-Towage (Outbound),ETC-Towage (Outbound),T-Towage (Outbound),null
+PTC-Towage (Outbound),PTC-Towage (Outbound),PLN,CMPL,OUTB,TOWG,null,Port Departure Planning And Services Completion,REQUIRED,False,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
+Cancel Towage (Outbound),Cancel Towage (Outbound),ACT,CANC,OUTB,TOWG,null,OMIT Port Call Or Cancel A Service,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Towage (Outbound),null
+ETS-Towage (Shifting),ETS-Towage (Shifting),EST,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTS-Towage (Shifting),RTS-Towage (Shifting),T-Towage (Shifting),null
+RTS-Towage (Shifting),RTS-Towage (Shifting),REQ,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Towage (Shifting),ETS-Towage (Shifting),T-Towage (Shifting),null
+PTS-Towage (Shifting),PTS-Towage (Shifting),PLN,STRT,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
+ETC-Towage (Shifting),ETC-Towage (Shifting),EST,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,RTC-Towage (Shifting),RTC-Towage (Shifting),T-Towage (Shifting),null
+RTC-Towage (Shifting),RTC-Towage (Shifting),REQ,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTC-Towage (Shifting),ETC-Towage (Shifting),T-Towage (Shifting),null
+PTC-Towage (Shifting),PTC-Towage (Shifting),PLN,CMPL,SHIF,TOWG,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
+Cancel Towage (Shifting),Cancel Towage (Shifting),ACT,CANC,SHIF,TOWG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Towage (Shifting),null
+ATC-Cargo Ops Load,ATC-Cargo Ops Load,ACT,CMPL,ALGS,LCRO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+ATC-Cargo Ops,ATC-Cargo Ops,ACT,CMPL,ALGS,CRGO,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+Cancel Cargo Ops,Cancel Cargo Ops,ACT,CANC,ALGS,CRGO,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
+ETS-Mooring (Outbound),ETS-Mooring (Outbound),EST,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTS-Mooring (Outbound),RTS-Mooring (Outbound),T-Mooring (Outbound),null
+RTS-Mooring (Outbound),RTS-Mooring (Outbound),REQ,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTS-Mooring (Outbound),ETS-Mooring (Outbound),T-Mooring (Outbound),null
+PTS-Mooring (Outbound),PTS-Mooring (Outbound),PLN,STRT,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
+ATS-Mooring (Outbound),ATS-Mooring (Outbound),ACT,STRT,OUTB,MOOR,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
+ETC-Mooring (Outbound),ETC-Mooring (Outbound),EST,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,RTC-Mooring (Outbound),RTC-Mooring (Outbound),T-Mooring (Outbound),null
+RTC-Mooring (Outbound),RTC-Mooring (Outbound),REQ,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Mooring (Outbound),ETC-Mooring (Outbound),T-Mooring (Outbound),null
+PTC-Mooring (Outbound),PTC-Mooring (Outbound),PLN,CMPL,OUTB,MOOR,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
+ATC-Mooring (Outbound),ATC-Mooring (Outbound),ACT,CMPL,OUTB,MOOR,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
+Cancel Mooring (Outbound),Cancel Mooring (Outbound),ACT,CANC,OUTB,MOOR,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Mooring (Outbound),null
+ATC Lashing,ATC Lashing,ACT,CMPL,ALGS,LASH,BRTH,Port Departure Planning And Services Completion,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
+Terminal Ready for vessel departure,Terminal Ready for vessel departure,ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
+Vessel Ready to sail,Vessel Ready to sail,ACT,DEPA,ALGS,VRDY,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,Special,null
+Vessel Ready to sail [JIT 1.1],Vessel Ready to sail [JIT 1.1],ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,Vessel Ready to sail
+ATD-Berth,ATD-Berth,ACT,DEPA,OUTB,null,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TD-Berth,null
+ATD-Berth (<implicit>),ATD-Berth (<implicit>),ACT,DEPA,null,null,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TD-Berth,ATD-Berth
+ATS-Pilotage (Outbound),ATS-Pilotage (Outbound),ACT,STRT,OUTB,PILO,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
+ATC-Pilotage (Outbound),ATC-Pilotage (Outbound),ACT,CMPL,OUTB,PILO,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
+ATS-Pilotage (Shifting),ATS-Pilotage (Shifting),ACT,STRT,SHIF,PILO,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
+ATC-Pilotage (Shifting),ATC-Pilotage (Shifting),ACT,CMPL,SHIF,PILO,BRTH,Port Departure Execution,EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
+ATS-Towage (Outbound),ATS-Towage (Outbound),ACT,STRT,OUTB,TOWG,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
+ATC-Towage (Outbound),ATC-Towage (Outbound),ACT,CMPL,OUTB,TOWG,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
+ATS-Towage (Shifting),ATS-Towage (Shifting),ACT,STRT,SHIF,TOWG,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
+ATC-Towage (Shifting),ATC-Towage (Shifting),ACT,CMPL,SHIF,TOWG,BRTH,Port Departure Execution,EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
+SOSP,SOSP,ACT,DEPA,OUTB,null,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,Special,null
+ETA-Anchorage,ETA-Anchorage,EST,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,RTA-Anchorage,RTA-Anchorage,T-Anchorage,null
+ETD-Anchorage,ETD-Anchorage,EST,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,RTD-Anchorage,RTD-Anchorage,T-Anchorage,null
+RTA-Anchorage,RTA-Anchorage,REQ,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,False,OPTIONAL,False,jit1_2,PTA-Anchorage,ETA-Anchorage,T-Anchorage,null
+RTD-Anchorage,RTD-Anchorage,REQ,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,False,OPTIONAL,False,jit1_2,PTD-Anchorage,ETD-Anchorage,T-Anchorage,null
+PTA-Anchorage,PTA-Anchorage,PLN,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+PTD-Anchorage,PTD-Anchorage,PLN,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATA-Anchorage,ATA-Anchorage,ACT,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATD-Anchorage,ATD-Anchorage,ACT,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATS-Anchorage Ops,ATS-Anchorage Ops,ACT,STRT,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATC-Anchorage Ops,ATC-Anchorage Ops,ACT,CMPL,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ETS-Sludge@Anchorage,ETS-Sludge@Anchorage,EST,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,RTS-Sludge@Anchorage,RTS-Sludge@Anchorage,T-Sludge,null
+ETS-Sludge@Berth,ETS-Sludge@Berth,EST,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,RTS-Sludge@Berth,RTS-Sludge@Berth,T-Sludge,null
+PTS-Sludge@Anchorage,PTS-Sludge@Anchorage,PLN,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+PTS-Sludge@Berth,PTS-Sludge@Berth,PLN,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+RTS-Sludge@Anchorage,RTS-Sludge@Anchorage,REQ,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,PTS-Sludge@Anchorage,ETS-Sludge@Anchorage,T-Sludge,null
+RTS-Sludge@Berth,RTS-Sludge@Berth,REQ,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,PTS-Sludge@Berth,ETS-Sludge@Berth,T-Sludge,null
+ATS-Sludge@Anchorage,ATS-Sludge@Anchorage,ACT,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+ATS-Sludge@Berth,ATS-Sludge@Berth,ACT,STRT,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+ETC-Sludge@Anchorage,ETC-Sludge@Anchorage,EST,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,RTC-Sludge@Anchorage,RTC-Sludge@Anchorage,T-Sludge,null
+ETC-Sludge@Berth,ETC-Sludge@Berth,EST,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,RTC-Sludge@Berth,RTC-Sludge@Berth,T-Sludge,null
+PTC-Sludge@Anchorage,PTC-Sludge@Anchorage,PLN,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+PTC-Sludge@Berth,PTC-Sludge@Berth,PLN,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+RTC-Sludge@Anchorage,RTC-Sludge@Anchorage,REQ,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,PTC-Sludge@Anchorage,ETC-Sludge@Anchorage,T-Sludge,null
+RTC-Sludge@Berth,RTC-Sludge@Berth,REQ,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,PTC-Sludge@Berth,ETC-Sludge@Berth,T-Sludge,null
+ATC-Sludge@Anchorage,ATC-Sludge@Anchorage,ACT,CMPL,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+ATC-Sludge@Berth,ATC-Sludge@Berth,ACT,CMPL,null,SLUG,BRTH,Other Services - Sludge Planning And Execution,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+Cancel Sludge@Anchorage,Cancel Sludge@Anchorage,ACT,CANC,null,SLUG,ANCH,OMIT Port Call Or Cancel A Service,REQUIRED,False,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+Cancel Sludge@Berth,Cancel Sludge@Berth,ACT,CANC,null,SLUG,BRTH,OMIT Port Call Or Cancel A Service,REQUIRED,True,False,OPTIONAL,False,jit1_2,null,null,T-Sludge,null
+ATS-Shore Power,ATS-Shore Power,ACT,STRT,ALGS,SHPW,BRTH,Other Services - Shore Power Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Shore Power,null
+ATC-Shore Power,ATC-Shore Power,ACT,CMPL,ALGS,SHPW,BRTH,Other Services - Shore Power Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Shore Power,null
+Omit Port Call,Omit Port Call,ACT,OMIT,null,null,null,OMIT Port Call Or Cancel A Service,EXCLUDED,False,False,OPTIONAL,False,jit1_2,null,null,Special,null

--- a/datamodel/samples.d/timestampdefinitions.csv
+++ b/datamodel/samples.d/timestampdefinitions.csv
@@ -1,12 +1,12 @@
 timestampID,timestampTypeName,eventClassifierCode,operationsEventTypeCode,portCallPhaseTypeCode,portCallServiceTypeCode,facilityTypeCode,portCallPart,eventLocationRequirement,isTerminalNeeded,isVesselDraftRelevant,vesselPositionRequirement,isMilesToDestinationRelevant,providedInStandard,acceptTimestampDefinition,rejectTimestampDefinition,negotiationCycle,implicitVariantOf
-ETA-Berth,ETA-Berth,EST,ARRI,INBD,null,BRTH,Berth Arrival Planning,OPTIONAL,True,False,OPTIONAL,True,jit1_1,RTA-Berth,RTA-Berth,TA-Berth,null
-ETA-Berth (<implicit>),ETA-Berth (<implicit>),EST,ARRI,null,null,BRTH,Berth Arrival Planning,OPTIONAL,True,False,OPTIONAL,True,jit1_0,RTA-Berth (<implicit>),RTA-Berth (<implicit>),TA-Berth,ETA-Berth
+ETA-Berth,ETA-Berth,EST,ARRI,INBD,null,BRTH,Berth Arrival Planning,OPTIONAL,True,True,OPTIONAL,True,jit1_1,RTA-Berth,RTA-Berth,TA-Berth,null
+ETA-Berth (<implicit>),ETA-Berth (<implicit>),EST,ARRI,null,null,BRTH,Berth Arrival Planning,OPTIONAL,True,True,OPTIONAL,True,jit1_0,RTA-Berth (<implicit>),RTA-Berth (<implicit>),TA-Berth,ETA-Berth
 RTA-Berth,RTA-Berth,REQ,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTA-Berth,ETA-Berth,TA-Berth,null
 RTA-Berth (<implicit>),RTA-Berth (<implicit>),REQ,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,EXCLUDED,False,jit1_0,PTA-Berth (<implicit>),ETA-Berth (<implicit>),TA-Berth,RTA-Berth
-PTA-Berth,PTA-Berth,PLN,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,OPTIONAL,True,jit1_1,null,null,TA-Berth,null
-PTA-Berth (<implicit>),PTA-Berth (<implicit>),PLN,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,False,OPTIONAL,True,jit1_0,null,null,TA-Berth,PTA-Berth
-ATA-Berth,ATA-Berth,ACT,ARRI,INBD,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,TA-Berth,null
-ATA-Berth (<implicit>),ATA-Berth (<implicit>),ACT,ARRI,null,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TA-Berth,ATA-Berth
+PTA-Berth,PTA-Berth,PLN,ARRI,INBD,null,BRTH,Berth Arrival Planning,REQUIRED,True,True,OPTIONAL,True,jit1_1,null,null,TA-Berth,null
+PTA-Berth (<implicit>),PTA-Berth (<implicit>),PLN,ARRI,null,null,BRTH,Berth Arrival Planning,REQUIRED,True,True,OPTIONAL,True,jit1_0,null,null,TA-Berth,PTA-Berth
+ATA-Berth,ATA-Berth,ACT,ARRI,INBD,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,True,EXCLUDED,False,jit1_1,null,null,TA-Berth,null
+ATA-Berth (<implicit>),ATA-Berth (<implicit>),ACT,ARRI,null,null,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,True,True,EXCLUDED,False,jit1_0,null,null,TA-Berth,ATA-Berth
 ETS-Cargo Ops,ETS-Cargo Ops,EST,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,RTS-Cargo Ops,RTS-Cargo Ops,T-Cargo Ops,null
 RTS-Cargo Ops,RTS-Cargo Ops,REQ,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_1,PTS-Cargo Ops,ETS-Cargo Ops,T-Cargo Ops,null
 PTS-Cargo Ops,PTS-Cargo Ops,PLN,STRT,ALGS,CRGO,BRTH,Services Planning,REQUIRED,True,False,OPTIONAL,False,jit1_1,null,null,T-Cargo Ops,null
@@ -90,19 +90,19 @@ RTC-Bunkering@Anchorage (<implicit>),RTC-Bunkering@Anchorage (<implicit>),REQ,CM
 RTC-Bunkering@Berth (<implicit>),RTC-Bunkering@Berth (<implicit>),REQ,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,PTC-Bunkering@Berth (<implicit>),ETC-Bunkering@Berth (<implicit>),T-Bunkering,RTC-Bunkering@Berth
 PTC-Bunkering@Anchorage (<implicit>),PTC-Bunkering@Anchorage (<implicit>),PLN,CMPL,null,BUNK,ANCH,Services Planning,REQUIRED,False,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Anchorage
 PTC-Bunkering@Berth (<implicit>),PTC-Bunkering@Berth (<implicit>),PLN,CMPL,null,BUNK,BRTH,Services Planning,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Bunkering,PTC-Bunkering@Berth
-ETA-PBP,ETA-PBP,EST,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,RTA-PBP,RTA-PBP,TA-PBPL,null
-ETA-PBP (<implicit>),ETA-PBP (<implicit>),EST,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,RTA-PBP (<implicit>),RTA-PBP (<implicit>),TA-PBPL,ETA-PBP
+ETA-PBP,ETA-PBP,EST,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,RTA-PBP,RTA-PBP,TA-PBPL,null
+ETA-PBP (<implicit>),ETA-PBP (<implicit>),EST,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,RTA-PBP (<implicit>),RTA-PBP (<implicit>),TA-PBPL,ETA-PBP
 RTA-PBP,RTA-PBP,REQ,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,False,jit1_0,PTA-PBP,ETA-PBP,TA-PBPL,null
 RTA-PBP (<implicit>),RTA-PBP (<implicit>),REQ,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,False,jit1_0,PTA-PBP (<implicit>),ETA-PBP (<implicit>),TA-PBPL,RTA-PBP
-PTA-PBP,PTA-PBP,PLN,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
-PTA-PBP (<implicit>),PTA-PBP (<implicit>),PLN,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,PTA-PBP
-ATA-PBP,ATA-PBP,ACT,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
-ATA-PBP (<implicit>),ATA-PBP (<implicit>),ACT,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,False,EXCLUDED,True,jit1_0,null,null,TA-PBPL,ATA-PBP
-ESOP,ESOP,ACT,ARRI,INBD,null,null,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,False,False,OPTIONAL,True,jit1_1,null,null,Special,null
+PTA-PBP,PTA-PBP,PLN,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
+PTA-PBP (<implicit>),PTA-PBP (<implicit>),PLN,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,null,null,TA-PBPL,PTA-PBP
+ATA-PBP,ATA-PBP,ACT,ARRI,INBD,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,null,null,TA-PBPL,null
+ATA-PBP (<implicit>),ATA-PBP (<implicit>),ACT,ARRI,null,null,PBPL,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",REQUIRED,False,True,EXCLUDED,True,jit1_0,null,null,TA-PBPL,ATA-PBP
+ESOP,ESOP,ACT,ARRI,INBD,null,null,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,False,True,OPTIONAL,True,jit1_1,null,null,Special,null
 AT All fast,AT All fast,ACT,ARRI,ALGS,FAST,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
 Gangway Down and Safe,Gangway Down and Safe,ACT,ARRI,ALGS,GWAY,BRTH,"Pilot Boarding Place Arrival Planning And Execution, Berth Arrival Execution",EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
-Vessel Readiness for Cargo operations,Vessel Readiness for Cargo operations,ACT,ARRI,ALGS,VRDY,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,Special,null
-Vessel Readiness for Cargo operations [JIT 1.1],Vessel Readiness for Cargo operations [JIT 1.1],ACT,ARRI,ALGS,SAFE,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,Vessel Readiness for Cargo operations
+Vessel Readiness for Cargo operations,Vessel Readiness for Cargo operations,ACT,ARRI,ALGS,VRDY,BRTH,Start Cargo Operations And Services,REQUIRED,True,True,EXCLUDED,False,jit1_2,null,null,Special,null
+Vessel Readiness for Cargo operations [JIT 1.1],Vessel Readiness for Cargo operations [JIT 1.1],ACT,ARRI,ALGS,SAFE,BRTH,Start Cargo Operations And Services,REQUIRED,True,True,EXCLUDED,False,jit1_1,null,null,Special,Vessel Readiness for Cargo operations
 ATS-Cargo Ops,ATS-Cargo Ops,ACT,STRT,ALGS,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,null
 ATS-Cargo Ops (<implicit>),ATS-Cargo Ops (<implicit>),ACT,STRT,null,CRGO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,T-Cargo Ops,ATS-Cargo Ops
 ATS-Cargo Ops Discharge,ATS-Cargo Ops Discharge,ACT,STRT,ALGS,DCRO,BRTH,Start Cargo Operations And Services,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,T-Cargo Ops,null
@@ -169,8 +169,8 @@ ATC Lashing,ATC Lashing,ACT,CMPL,ALGS,LASH,BRTH,Port Departure Planning And Serv
 Terminal Ready for vessel departure,Terminal Ready for vessel departure,ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,null
 Vessel Ready to sail,Vessel Ready to sail,ACT,DEPA,ALGS,VRDY,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_2,null,null,Special,null
 Vessel Ready to sail [JIT 1.1],Vessel Ready to sail [JIT 1.1],ACT,DEPA,ALGS,SAFE,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,Special,Vessel Ready to sail
-ATD-Berth,ATD-Berth,ACT,DEPA,OUTB,null,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TD-Berth,null
-ATD-Berth (<implicit>),ATD-Berth (<implicit>),ACT,DEPA,null,null,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_0,null,null,TD-Berth,ATD-Berth
+ATD-Berth,ATD-Berth,ACT,DEPA,OUTB,null,BRTH,Port Departure Execution,REQUIRED,True,True,EXCLUDED,False,jit1_0,null,null,TD-Berth,null
+ATD-Berth (<implicit>),ATD-Berth (<implicit>),ACT,DEPA,null,null,BRTH,Port Departure Execution,REQUIRED,True,True,EXCLUDED,False,jit1_0,null,null,TD-Berth,ATD-Berth
 ATS-Pilotage (Outbound),ATS-Pilotage (Outbound),ACT,STRT,OUTB,PILO,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
 ATC-Pilotage (Outbound),ATC-Pilotage (Outbound),ACT,CMPL,OUTB,PILO,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Outbound),null
 ATS-Pilotage (Shifting),ATS-Pilotage (Shifting),ACT,STRT,SHIF,PILO,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Pilotage (Shifting),null
@@ -179,15 +179,15 @@ ATS-Towage (Outbound),ATS-Towage (Outbound),ACT,STRT,OUTB,TOWG,BRTH,Port Departu
 ATC-Towage (Outbound),ATC-Towage (Outbound),ACT,CMPL,OUTB,TOWG,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Outbound),null
 ATS-Towage (Shifting),ATS-Towage (Shifting),ACT,STRT,SHIF,TOWG,BRTH,Port Departure Execution,REQUIRED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
 ATC-Towage (Shifting),ATC-Towage (Shifting),ACT,CMPL,SHIF,TOWG,BRTH,Port Departure Execution,EXCLUDED,True,False,EXCLUDED,False,jit1_1,null,null,T-Towage (Shifting),null
-SOSP,SOSP,ACT,DEPA,OUTB,null,null,Port Departure Execution,EXCLUDED,False,False,EXCLUDED,False,jit1_1,null,null,Special,null
-ETA-Anchorage,ETA-Anchorage,EST,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,RTA-Anchorage,RTA-Anchorage,T-Anchorage,null
-ETD-Anchorage,ETD-Anchorage,EST,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,RTD-Anchorage,RTD-Anchorage,T-Anchorage,null
+SOSP,SOSP,ACT,DEPA,OUTB,null,null,Port Departure Execution,EXCLUDED,False,True,EXCLUDED,False,jit1_1,null,null,Special,null
+ETA-Anchorage,ETA-Anchorage,EST,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,RTA-Anchorage,RTA-Anchorage,T-Anchorage,null
+ETD-Anchorage,ETD-Anchorage,EST,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,RTD-Anchorage,RTD-Anchorage,T-Anchorage,null
 RTA-Anchorage,RTA-Anchorage,REQ,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,False,OPTIONAL,False,jit1_2,PTA-Anchorage,ETA-Anchorage,T-Anchorage,null
 RTD-Anchorage,RTD-Anchorage,REQ,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,EXCLUDED,False,False,OPTIONAL,False,jit1_2,PTD-Anchorage,ETD-Anchorage,T-Anchorage,null
-PTA-Anchorage,PTA-Anchorage,PLN,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-PTD-Anchorage,PTD-Anchorage,PLN,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATA-Anchorage,ATA-Anchorage,ACT,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
-ATD-Anchorage,ATD-Anchorage,ACT,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+PTA-Anchorage,PTA-Anchorage,PLN,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+PTD-Anchorage,PTD-Anchorage,PLN,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATA-Anchorage,ATA-Anchorage,ACT,ARRI,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
+ATD-Anchorage,ATD-Anchorage,ACT,DEPA,null,null,ANCH,Other Services - Anchorage Planning And Execution,OPTIONAL,False,True,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
 ATS-Anchorage Ops,ATS-Anchorage Ops,ACT,STRT,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
 ATC-Anchorage Ops,ATC-Anchorage Ops,ACT,CMPL,null,ANCO,ANCH,Other Services - Anchorage Planning And Execution,REQUIRED,False,False,OPTIONAL,True,jit1_2,null,null,T-Anchorage,null
 ETS-Sludge@Anchorage,ETS-Sludge@Anchorage,EST,STRT,null,SLUG,ANCH,Other Services - Sludge Planning And Execution,REQUIRED,False,False,OPTIONAL,False,jit1_2,RTS-Sludge@Anchorage,RTS-Sludge@Anchorage,T-Sludge,null


### PR DESCRIPTION
This PR provides a new `is_vessel_draft_relevant` field and defines it for the simple cases.

There will be a follow up commit once Charles have confirmed some changes with Slavia. However, this selection is sufficient to get started and enable us to test the new field from end to end.