### PR TITLE
Remove AFD from cut off times

### DIFF
--- a/datamodel/referencedata.d/cutofftimecodes.csv
+++ b/datamodel/referencedata.d/cutofftimecodes.csv
@@ -5,4 +5,3 @@ FCO,FCL delivery cut-off,Latest deadline for delivering containers at the termin
 LCO,LCL delivery cut-off,Latest deadline for delivering LCL cargo at the container freight station
 ECP,Empty container pick-up date and time,Time and date for shipper to pick-up empty container(s)
 EFC,Earliest full-container delivery date,Earliest date where containers can be delivered at the terminal gate also called gate-opening
-AFD,AMS filing due date,Date when AMS filing should latest be done in the last port of call before visiting the first US port

--- a/datamodel/testdata.d/08_04_test_data_bkg.sql
+++ b/datamodel/testdata.d/08_04_test_data_bkg.sql
@@ -11,7 +11,7 @@ INSERT INTO dcsa_im_v3_0.shipment_cutoff_time (
     cut_off_time
 ) VALUES (
     (SELECT id FROM dcsa_im_v3_0.shipment WHERE carrier_booking_reference = 'ABC123123123'),
-    'AFD',
+    'EFC',
     DATE '2021-03-09'
 );
 


### PR DESCRIPTION
`AFD` Cut-Off Time Code is no longer needed as it is covered by **Advance Manifest Filing**